### PR TITLE
[WORK IN PROGRESS] Food Computer v1 Fixture

### DIFF
--- a/fixtures/food_computer_1.0.json
+++ b/fixtures/food_computer_1.0.json
@@ -11,8 +11,22 @@
     },
     {
       "_id": "gc0012_1",
-      "type:": "gc0012",
-      "environment": "environment_1"
+      "type": "gc0012",
+      "environment": "environment_1",
+      "arguments": [1],
+      "outputs": {
+        "air_carbon_dioxide": {"variable": "air_carbon_dioxide"}
+      }
+    },
+    {
+      "_id": "dht22_1",
+      "type": "dht22",
+      "environment": "environment_1",
+      "arguments": [5],
+      "outputs": {
+        "air_temperature": {"variable": "air_temperature"},
+        "air_humidity": {"variable": "air_humidity"}
+      }
     }
   ],
   "software_module": [

--- a/fixtures/food_computer_1.0.json
+++ b/fixtures/food_computer_1.0.json
@@ -1,0 +1,15 @@
+{
+  "firmware_module": [
+    {
+      "_id": "ds18b20_1",
+      "type": "ds18b20",
+      "environment": "environment_1",
+      "arguments": [4],
+      "outputs": {
+        "temperature": {"variable": "water_temperature"}
+      }
+    }
+  ],
+  "software_module": [
+  ]
+}

--- a/fixtures/food_computer_1.0.json
+++ b/fixtures/food_computer_1.0.json
@@ -8,6 +8,11 @@
       "outputs": {
         "temperature": {"variable": "water_temperature"}
       }
+    },
+    {
+      "_id": "gc0012_1",
+      "type:": "gc0012",
+      "environment": "environment_1"
     }
   ],
   "software_module": [


### PR DESCRIPTION
This is the list of sensors in the BOM for the Food Computer v1. Checked means "added to fixture and tested with openag_brain on Raspberry Pi 2".
- [x]  dht22 - air temp / humidity
- [x]  gc0011 - co2
- [ ]  dFrobot - ph
- [ ]  dFrobot - ec
- [x]  ds18b20  - water temp
- [ ]  ts12561 - light
