### PR TITLE
CORS removed

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -51,7 +51,7 @@
   <run_depend>python-requests</run_depend>
   <run_depend>python-gevent</run_depend>
   <run_depend>python-flask</run_depend>
-  <run_depend>python-flask-cors-pip</run_depend>
+
   <run_depend>python-lxml</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/openag_brain/software_modules/api.py
+++ b/src/openag_brain/software_modules/api.py
@@ -14,7 +14,6 @@ import rostopic
 import rosgraph
 import rosservice
 from flask import Flask, jsonify, request, Response
-from flask_cors import CORS
 from gevent.wsgi import WSGIServer
 from gevent.queue import Queue
 
@@ -22,7 +21,6 @@ API_VER = "0.0.1"
 
 app = Flask(__name__)
 app.debug = True
-CORS(app)
 
 @app.errorhandler(socket.error)
 @app.errorhandler(rosservice.ROSServiceIOException)


### PR DESCRIPTION
Based on [this discussion](https://github.com/OpenAgInitiative/openag_brain_docker_rpi/pull/12) openag_brain api is supposed to be run through CouchDb proxy which already has CORS enabled. So this one has to be removed to avoid error with multiple values set 
>The 'Access-Control-Allow-Origin' header contains multiple values 'http://localhost, http://localhost', but only one is allowed