### PR TITLE
Fix regression to recipe start/stop

### DIFF
--- a/src/openag_brain/software_modules/api.py
+++ b/src/openag_brain/software_modules/api.py
@@ -36,8 +36,6 @@ def success(msg, status_code=200):
 
 rostopic_master = rosgraph.Master("/rostopic")
 rosnode_master = rosgraph.Master("/rosnode")
-# Register api with roscore
-rospy.init_node("api")
 
 @app.route("/api/{v}/param".format(v=API_VER), methods=["GET"])
 def list_params():


### PR DESCRIPTION
Fix regression to recipe_start introduced when adding an API endpoint.

Tested on Raspberry Pi 3 / Arduino Mega.

Fixes https://github.com/OpenAgInitiative/openag_brain/issues/52.