### PR TITLE
Change -f flag to use absolute filepaths for fixtures

### DIFF
--- a/scripts/main
+++ b/scripts/main
@@ -88,6 +88,17 @@ def main(api_server, db_server, fixtures, screen):
             print "Spawning software modules"
             modules = spawn_modules(screen)
 
+def resolve_fixtures(fixtures):
+    """
+    Given a list of fixture names, returns a list of fully resolved fixture
+    paths.
+    """
+    rospack = rospkg.RosPack()
+    pkg_path = rospack.get_path('openag_brain')
+    fixtures_path = os.path.join(pkg_path, "fixtures")
+    resolved = [os.path.join(fixtures_path, fixture_name + ".json") for fixture_name in fixtures]
+    return resolved
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="""
@@ -109,13 +120,24 @@ the configuration of the software modules
         default=[], action='append', dest='fixtures'
     )
     parser.add_argument(
+        '-F', '--fixture-path',
+        help="""
+Path to a json fixture file to apply to the database. Specify the full path to
+the fixture file. This flag is useful for loading fixtures not located in the
+default fixtures directory.
+        """,
+        default=[], action='append', dest='fixture_paths'
+    )
+    parser.add_argument(
         "--screen", action="store_true",
         help="""
 Passes the --screen flag to the roslaunch call, which forces all node output to
-the screen. Useful for debugging
+the screen. Useful for debugging.
 """)
     vals = parser.parse_args()
+    # Resolve named fixtures, then join named fixtures and path fixtures.
+    fixture_paths = resolve_fixtures(vals.fixtures) + vals.fixture_paths
     main(
         api_server=vals.api_server, db_server=vals.db_server,
-        fixtures=vals.fixtures, screen=vals.screen
+        fixtures=fixture_paths, screen=vals.screen
     )

--- a/scripts/main
+++ b/scripts/main
@@ -51,7 +51,7 @@ def main(api_server, db_server, fixtures, screen):
         if subprocess.call(
             ["openag", "db", "load_fixture", fixture_path]
         ):
-            raise RuntimeError("Failed to load fixture " + fixture_name)
+            raise RuntimeError("Failed to load fixture " + fixture_path)
 
     # Start the software modules
     print "Generating launch file"

--- a/scripts/main
+++ b/scripts/main
@@ -46,10 +46,8 @@ def main(api_server, db_server, fixtures, screen):
     # Load the fixture
     rospack = rospkg.RosPack()
     pkg_path = rospack.get_path('openag_brain')
-    fixtures_path = os.path.join(pkg_path, "fixtures")
-    for fixture_name in fixtures:
-        print "Applying fixture {}".format(fixture_name)
-        fixture_path = os.path.join(fixtures_path, fixture_name + ".json")
+    for fixture_path in fixtures:
+        print "Applying fixture {}".format(fixture_path)
         if subprocess.call(
             ["openag", "db", "load_fixture", fixture_path]
         ):

--- a/scripts/main
+++ b/scripts/main
@@ -120,7 +120,7 @@ the configuration of the software modules
         default=[], action='append', dest='fixtures'
     )
     parser.add_argument(
-        '-F', '--fixture-path',
+        '-F', '--fixture_path',
         help="""
 Path to a json fixture file to apply to the database. Specify the full path to
 the fixture file. This flag is useful for loading fixtures not located in the

--- a/scripts/main
+++ b/scripts/main
@@ -44,8 +44,6 @@ def main(api_server, db_server, fixtures, screen):
     server = Server(db_server)
 
     # Load the fixture
-    rospack = rospkg.RosPack()
-    pkg_path = rospack.get_path('openag_brain')
     for fixture_path in fixtures:
         print "Applying fixture {}".format(fixture_path)
         if subprocess.call(


### PR DESCRIPTION
## Rationale

Makes it easier to build custom Docker images from rpi brain by providing an absolute reference to your own 3rd party fixture file.

```Dockerfile
FROM openag/rpi_brain

USER pi
# Get the fixture files
RUN cd ~ && git clone http://github.com/me/my_fixture.git
CMD ["~/catkin_ws/devel/env.sh", "rosrun", "openag_brain", "main", "-f", "~/my_fixture/fixture.json"]
```

## Usage

Old:

    rosrun openag_brain main -f default

New:

    rosrun openag_brain main -f ~/path/to/default.json

## Note

Before merging, we should make a corresponding change to `docker-compose.yml` in https://github.com/OpenAgInitiative/openag_brain_docker_rpi.