### PR TITLE
Add category "actuators" to actuator firmware types

### DIFF
--- a/fixtures/default.json
+++ b/fixtures/default.json
@@ -200,7 +200,8 @@
       ],
       "inputs": {
         "cmd": {
-          "type": "std_msgs/Bool"
+          "type": "std_msgs/Bool",
+          "categories": ["actuators"]
         }
       },
       "dependencies": [
@@ -341,7 +342,8 @@
       ],
       "inputs": {
         "cmd": {
-          "type": "std_msgs/Float32"
+          "type": "std_msgs/Float32",
+          "categories": ["actuators"]
         }
       },
       "dependencies": [
@@ -375,7 +377,8 @@
       ],
       "inputs": {
         "cmd": {
-          "type": "std_msgs/Float32"
+          "type": "std_msgs/Float32",
+          "categories": ["actuators"]
         }
       },
       "dependencies": [


### PR DESCRIPTION
Fixes https://github.com/OpenAgInitiative/openag_brain/issues/67.