### PR TITLE
Fix init_node bug in api by using ServiceProxy

### DIFF
--- a/src/openag_brain/software_modules/api.py
+++ b/src/openag_brain/software_modules/api.py
@@ -109,7 +109,7 @@ def get_service_info(service_name):
 @app.route("/api/{v}/service/<path:service_name>".format(v=API_VER), methods=["POST"])
 def perform_service_call(service_name):
     """
-    POST  /api/<version>/service/<service_name>
+    POST /api/<version>/service/<service_name>
 
     POST to a service to change it somehow. service_name may be a path.
 

--- a/src/openag_brain/software_modules/api.py
+++ b/src/openag_brain/software_modules/api.py
@@ -219,15 +219,16 @@ def post_topic_message(topic_name):
     except StopIteration:
         # If we can't find the topic, return early (400 bad request).
         return error("Topic does not exist")
-    # Get the message type constructor for the topic's type string.
+    json = request.get_json(silent=True)
+    args = json if json else []
     try:
+        # Get the message type constructor for the topic's type string.
         MsgType = get_message_class(topic_match[1])
-        msg_args = request.get_json()
         pub = rospy.Publisher(topic_name, MsgType, queue_size=10)
         # Unpack JSON list and pass to publish.
         # pub.publish() will pass the list of arguments to the message
         # type constructor.
-        pub.publish(*msg_args)
+        pub.publish(*args)
     except Exception, e:
         return error("Wrong arguments for topic type constructor")
     return success("Posted message to topic")


### PR DESCRIPTION
We previously used rosservice.call_service to call ROS services. It
turns out this is an internal API and does spooky unwanted things like
initializing a node from within the function. This is what caused
https://github.com/OpenAgInitiative/openag_brain/issues/52 and we
thought we had fixed it with https://github.com/OpenAgInitiative/openag_brain/pull/64/files#diff-d5fc26493f28134f9baefcdbeefdcf91L40.

Unfortunately, that didn't actually fix the problem. Removing init_node meant
that rosservice.call_service worked, but nothing else did (for example
publishing to a rostopic won't work if you don't initialize your node).

This fixes the issue by using the public API, ServiceProxy.

Unfortunately, ServiceProxy has a limitation that you must import the ROS
ServiceClass, which is autogenerated from srv files. This makes it difficult
to do a generalized endpoint for services, since we pass in the service name,
but don't know the name of the service class from the HTTP call.

This commit provides a fix by creating 2 static endpoints: /start_recipe and
/stop_recipe and removes the generalized POST API for services. It's not ideal,
but it works.