### PR TITLE
Flash script

### DIFF
--- a/scripts/flash
+++ b/scripts/flash
@@ -2,52 +2,19 @@
 import subprocess
 import argparse
 import tempfile
-import select
-
-# def log(x):
-#     print x
-
-# def handle_process(proc, err, stdout=None, stderr=None):
-#     """
-#     Takes a running subprocess.Popen object `proc`, logs everything it
-#     prints using `log` function, roswarns everything it prints to stderr, and raises
-#     `err` if it fails
-#     """
-#     poll = select.poll()
-#     poll.register(proc.stdout)
-#     poll.register(proc.stderr)
-#     while proc.poll() is None:
-#         res = poll.poll(1)
-#         for fd, evt in res:
-#             if not (evt & select.POLLIN):
-#                 continue
-#             if fd == proc.stdout.fileno():
-#                 line = proc.stdout.readline().strip()
-#                 if line:
-#                     stdout(line)
-#             elif fd == proc.stderr.fileno():
-#                 line = proc.stderr.readline().strip()
-#                 if line:
-#                     stderr(line)
-#     if proc.poll():
-#         proc.terminate()
-#         proc.wait()
-#         raise RuntimeError("Process interrupted")
-#     if proc.returncode:
-#         raise err
 
 def run_flash(build_dir):
-    print "Initializing PlatformIO firmware project for Arduino"
-    proc = subprocess.Popen(
-        ["openag", "firmware", "init"], cwd=self.build_dir
+    init_proc = subprocess.Popen(
+        ["openag", "firmware", "init"], cwd=build_dir
     )
-    print "Compiling and flashing firmware to Arduino"
-    proc = subprocess.Popen(
+    init_proc.wait()
+    flash_proc = subprocess.Popen(
         [
             "openag", "firmware", "run", "-p", "ros", "-t",
             "upload"
-        ], cwd=self.build_dir
+        ], cwd=build_dir
     )
+    flash_proc.wait()
     print "Done"
 
 

--- a/scripts/flash
+++ b/scripts/flash
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+import subprocess
+import argparse
+import tempfile
+import select
+
+# def log(x):
+#     print x
+
+# def handle_process(proc, err, stdout=None, stderr=None):
+#     """
+#     Takes a running subprocess.Popen object `proc`, logs everything it
+#     prints using `log` function, roswarns everything it prints to stderr, and raises
+#     `err` if it fails
+#     """
+#     poll = select.poll()
+#     poll.register(proc.stdout)
+#     poll.register(proc.stderr)
+#     while proc.poll() is None:
+#         res = poll.poll(1)
+#         for fd, evt in res:
+#             if not (evt & select.POLLIN):
+#                 continue
+#             if fd == proc.stdout.fileno():
+#                 line = proc.stdout.readline().strip()
+#                 if line:
+#                     stdout(line)
+#             elif fd == proc.stderr.fileno():
+#                 line = proc.stderr.readline().strip()
+#                 if line:
+#                     stderr(line)
+#     if proc.poll():
+#         proc.terminate()
+#         proc.wait()
+#         raise RuntimeError("Process interrupted")
+#     if proc.returncode:
+#         raise err
+
+def run_flash(build_dir):
+    print "Initializing PlatformIO firmware project for Arduino"
+    proc = subprocess.Popen(
+        ["openag", "firmware", "init"], cwd=self.build_dir
+    )
+    print "Compiling and flashing firmware to Arduino"
+    proc = subprocess.Popen(
+        [
+            "openag", "firmware", "run", "-p", "ros", "-t",
+            "upload"
+        ], cwd=self.build_dir
+    )
+    print "Done"
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="""
+Flashes Arduino with firmware_modules read from the CouchDB firmware_modules
+database.
+        """,
+    )
+    parser.add_argument(
+        "-d", "--build_dir",
+        help="The directory in which to initialize the PlatformIO project",
+        default=None
+    )
+
+    args = parser.parse_args()
+    build_dir = args.build_dir or tempfile.mkdtemp()
+    run_flash(build_dir)


### PR DESCRIPTION
This adds a new command 'flash` that allows users to flash the Arduino manually. Example:

    rosrun openag_brain flash --dir ~/build

`--dir` is optional, and a tmp directory will be generated if none is provided.