### PR TITLE
Turn off flashing by default. Add dev fixture to optionally turn it on.

### DIFF
--- a/fixtures/default.json
+++ b/fixtures/default.json
@@ -409,7 +409,7 @@
         "should_flash": {
           "type": "bool",
           "description": "Whether to flash the Arduino during setup",
-          "default": true
+          "default": false
         }
       }
     },

--- a/fixtures/dev.json
+++ b/fixtures/dev.json
@@ -1,0 +1,11 @@
+{
+  "software_module": [
+    {
+      "_id": "arduino_handler",
+      "type": "openag_brain:handle_arduino.py",
+      "parameters": {
+        "should_flash": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
With `openag_brain flash`, we now have a way to flash Arduino separately from the autoflash system. Having autoflash is nice-to-have for development and tinkering. This PR makes manual-flashing (have to run the command) the default and creates a `dev.json` fixture that will turn on autoflashing for those who want it.