### PR TITLE
[WIP] Loosely couple nodes via topics

### DIFF
--- a/src/openag_brain/commands/update_launch.py
+++ b/src/openag_brain/commands/update_launch.py
@@ -92,7 +92,13 @@ def update_launch(server):
 
     for module_id, module in modules.items():
         print 'Processing module "{}" from server'.format(module_id)
-        mod_ns = module.get("namespace", module.get("environment", None))
+        ns = module.get("namespace")
+        environment = module.get("environment")
+        mod_ns = (
+            ns if ns else
+            "environments/{}".format(environment) if environment else
+            None
+        )
         if not mod_ns in groups:
             group = create_group(root, mod_ns)
             groups[mod_ns] = group

--- a/src/openag_brain/software_modules/image_persistence.py
+++ b/src/openag_brain/software_modules/image_persistence.py
@@ -76,6 +76,14 @@ class ImagePersistence:
                 "Failed to post image to database: {}".format(res.content)
             )
 
+def gen_parsed_image_topics(pubs):
+    topic_pattern = "/environments/(\w+)/{}/measured".format(AERIAL_IMAGE)
+    for topic, topic_type in pubs:
+        result = match(topic_pattern, topic)
+        if result:
+            environment_id = result.groups(1)
+            yield (topic, topic_type, environment_id)
+
 if __name__ == '__main__':
     db_server = cli_config["local_server"]["url"]
     if not db_server:
@@ -90,18 +98,11 @@ if __name__ == '__main__':
         )
         min_update_interval = 3600
     env_var_db = server[ENVIRONMENTAL_DATA_POINT]
-    module_db = server[SOFTWARE_MODULE]
-    modules = {
-        module_id: SoftwareModule(module_db[module_id]) for module_id in
-        module_db if not module_id.startswith("_")
-    }
     persistence_objs = []
-    for module_id, module_info in modules.items():
-        if module_info.get("namespace", None) == "cameras":
-            topic = "/cameras/{}/image_raw".format(module_id)
-            persistence_objs.append(ImagePersistence(
-                db=env_var_db, topic=topic, variable=AERIAL_IMAGE,
-                environment=module_info["environment"],
-                min_update_interval=min_update_interval
-            ))
+    for topic, topic_type, environment_id in gen_parsed_image_topics(pubs):
+        persistence_objs.append(ImagePersistence(
+            db=env_var_db, topic=topic, variable=AERIAL_IMAGE,
+            environment=environment_id,
+            min_update_interval=min_update_interval
+        ))
     rospy.spin()

--- a/src/openag_brain/software_modules/image_persistence.py
+++ b/src/openag_brain/software_modules/image_persistence.py
@@ -11,11 +11,13 @@ for the environment are streams of images from connected webcams.
 """
 import time
 import rospy
+import rosgraph
 import requests
 from PIL import Image
 from couchdb import Server
 from StringIO import StringIO
 from sensor_msgs.msg import Image as ImageMsg
+from re import match
 
 from openag.cli.config import config as cli_config
 from openag.models import EnvironmentalDataPoint, SoftwareModule
@@ -90,6 +92,9 @@ if __name__ == '__main__':
         raise RuntimeError("No database server specified")
     server = Server(db_server)
     rospy.init_node('image_persistence_1')
+    rostopic_master = rosgraph.Master("/rostopic")
+    pubs, subs, _ = rostopic_master.getSystemState()
+
     try:
         min_update_interval = rospy.get_param("~min_update_interval")
     except KeyError:

--- a/src/openag_brain/software_modules/sensor_persistence.py
+++ b/src/openag_brain/software_modules/sensor_persistence.py
@@ -9,6 +9,7 @@ in the system.
 import sys
 import time
 import random
+from re import match
 
 import rospy
 import rostopic

--- a/src/openag_brain/software_modules/topic_filter.py
+++ b/src/openag_brain/software_modules/topic_filter.py
@@ -1,12 +1,8 @@
 #!/usr/bin/python
-import time
 import rospy
-from openag.cli.config import config as cli_config
-from openag.utils import synthesize_firmware_module_info
-from openag.models import FirmwareModule, FirmwareModuleType
-from openag.db_names import FIRMWARE_MODULE, FIRMWARE_MODULE_TYPE
-from couchdb import Server
+import rosgraph
 
+from re import match
 from roslib.message import get_message_class
 
 class EWMA:
@@ -34,32 +30,37 @@ def filter_topic(src_topic, dest_topic, topic_type):
     sub = rospy.Subscriber(src_topic, topic_type, callback)
     return sub, pub
 
-def filter_all_topics(module_db, module_type_db):
-    modules = {
-        module_id: FirmwareModule(module_db[module_id]) for module_id in
-        module_db if not module_id.startswith('_')
-    }
-    module_types = {
-        type_id: FirmwareModuleType(module_type_db[type_id]) for type_id in
-        module_type_db if not type_id.startswith("_")
-    }
-    modules = synthesize_firmware_module_info(modules, module_types)
-    for module_id, module_info in modules.items():
-        for output_name, output_info in module_info["outputs"].items():
-            src_topic = "/sensors/{}/{}/raw".format(module_id, output_name)
-            dest_topic = "/sensors/{}/{}/filtered".format(
-                module_id, output_name
-            )
-            topic_type = get_message_class(output_info["type"])
-            filter_topic(src_topic, dest_topic, topic_type)
+def gen_sensor_topic_desc(pubs):
+    """
+    Generate a description dict for topics that are sensor topics.
+    Matches, filters and parses topic names to find sensor information.
+    """
+    for topic, topic_type in pubs:
+        result = match("/sensors/(\w+)/(\w+)/raw", topic)
+        if result:
+            yield {
+                "module_id": result.groups(1),
+                "output_name": result.groups(2),
+                "topic": topic,
+                "type": topic_type
+            }
+
+def filter_all_topics(pubs):
+    """
+    Given an iterator publishers, where each publisher is a two-tuple
+    `(topic, type)`, create a filtered topic endpoint.
+    """
+    for desc in gen_sensor_topic_desc(pubs):
+        src_topic_type = get_message_class(desc["type"])
+        src_topic = desc["topic"]
+        module_id = desc["module_id"]
+        output_name = desc["output_name"]
+        dest_topic = "/sensors/{}/{}/filtered".format(module_id, output_name)
+        filter_topic(src_topic, dest_topic, src_topic_type)
 
 if __name__ == '__main__':
     rospy.init_node("topic_filter")
-    db_server = cli_config["local_server"]["url"]
-    if not db_server:
-        raise RuntimeError("No local server specified")
-    server = Server(db_server)
-    module_db = server[FIRMWARE_MODULE]
-    module_type_db = server[FIRMWARE_MODULE_TYPE]
-    filter_all_topics(module_db, module_type_db)
+    rostopic_master = rosgraph.Master("/rostopic")
+    pubs, subs, _ = rostopic_master.getSystemState()
+    filter_all_topics(pubs)
     rospy.spin()


### PR DESCRIPTION
This pull request does a few things:

- Places environment topics under `/environments/` namespace
- Decouples nodes from having to know about module configuration. The only thing a node should have to know to plug in to the system is which topics it cares to subscribe to.
- Moves `filtered` endpoint to `/environments/[id]/filtered/[variable]`, following the convention for other environmental data points.
- Updates persistence nodes to look for datapoints at `/environments/[id]/filtered/[variable]`, rather than tightly coupling them to sensors and cameras.

## Rational

By moving environments under an `/environments/` namespace, we follow the convention established in other parts of the system (`/sensors/`, `/actuators/`, etc).

By having persistence nodes look for datapoints at the environment level, we are able to decouple them from the details of a sensor's identity and implementation. This loose coupling has advantages for refactoring and modularity. Nodes no longer need to know the details of module configuration in order to function:

- The details of module configuration can be refactored or updated in future, without having to modify many nodes.
- Nodes don't have to care about the details of how data is created. Multiple sensors may be summed to produce a more accurate reading, for example.

With this approach, nodes are freed from having to know the details of module configuration. The only place we need to know module config details is in `topic_connector.py` (which is the node that deals with coupling topics anyway). Every other node can decide how to publish and subscribe simply by looking at the topic name.