### PR TITLE
Fix memory leak by removing view queries in main

### DIFF
--- a/scripts/main
+++ b/scripts/main
@@ -72,10 +72,6 @@ def main(api_server, db_server, fixtures, screen):
     )["last_seq"]
     while True:
         time.sleep(5)
-        # Query the environmental data point views regularly to force them to
-        # update
-        edp_db.view("openag/by_variable", stale="update_after")._fetch()
-        edp_db.view("openag/by_timestamp", stale="update_after")._fetch()
         software_changes = software_db.changes(since=last_software_seq)
         firmware_changes = firmware_db.changes(since=last_firmware_seq)
         last_software_seq = software_changes["last_seq"]


### PR DESCRIPTION
Diagnosis: when db reaches a certain size, creating the view cache takes quite a bit of time. At a certain point, that time exceeds 5s. However, we were requesting that view caches be rebuilt every 5s. If the cache takes longer than 5s to build, this ends up causing a memory leak, as the previous cache rebuild request is continually stomped by the next request.

This pull request fixes the issue by removing cache rebuild requests. Consumers can request cache rebuild themselves.