### PR TITLE
Added messages types for diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,11 +44,10 @@ catkin_python_setup()
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
+add_message_files(
+  FILES
+  DiagnosticStatus.msg
+)
 
 ## Generate services in the 'srv' folder
 add_service_files(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ catkin_python_setup()
 add_message_files(
   FILES
   DiagnosticStatus.msg
+  DiagnosticArray.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/msg/DiagnosticArray.msg
+++ b/msg/DiagnosticArray.msg
@@ -1,0 +1,2 @@
+Header header
+DiagnosticStatus[] status

--- a/msg/DiagnosticStatus.msg
+++ b/msg/DiagnosticStatus.msg
@@ -9,4 +9,4 @@ byte STALE=3
 
 byte level # level of operation enumerate above
 string name # a description of the test/component reporting
-uint8 status # a status code for the test/component
+uint8 code # a status code for the test/component

--- a/msg/DiagnosticStatus.msg
+++ b/msg/DiagnosticStatus.msg
@@ -1,0 +1,12 @@
+# The message holds the status of an individual component of the robot.
+# Based on diagnostic_msgs/DiagnosticStatus
+
+# Possible levels of operation
+byte OK=0
+byte WARN=1
+byte ERROR=2
+byte STALE=3
+
+byte level # level of operation enumerate above
+string name # a description of the test/component reporting
+uint8 status # a status code for the test/component


### PR DESCRIPTION
This is the start of a fix for #76. This creates the message types that will be sent from the Arduino to the Raspberry Pi instead of directly using the types from the [ROS diagnostics stack](http://wiki.ros.org/diagnostics). I will file another PR later with a module that performs the conversion between status codes and status messages.