### PR TITLE
Handle status codes

### DIFF
--- a/fixtures/default.json
+++ b/fixtures/default.json
@@ -25,7 +25,11 @@
       },
       "dependencies": [
         {"type": "git", "url": "https://github.com/OpenAgInitiative/openag_firmware_module.git"}
-      ]
+      ],
+      "status_codes": {
+        "1": "Sensor responded with the wrong function code",
+        "2": "Sensor did not return enough information"
+      }
     },
     {
       "_id": "atlas_do",
@@ -60,7 +64,12 @@
       },
       "dependencies": [
         {"type": "git", "url": "https://github.com/OpenAgInitiative/openag_firmware_module.git"}
-      ]
+      ],
+      "status_codes": {
+        "1": "No response",
+        "2": "Request failed",
+        "3": "Unknown error"
+      }
     },
     {
       "_id": "atlas_ec",
@@ -86,7 +95,12 @@
       },
       "dependencies": [
         {"type": "git", "url": "https://github.com/OpenAgInitiative/openag_firmware_module.git"}
-      ]
+      ],
+      "status_codes": {
+        "1": "No response",
+        "2": "Request failed",
+        "3": "Unknown error"
+      }
     },
     {
       "_id": "atlas_orp",
@@ -121,7 +135,12 @@
       },
       "dependencies": [
         {"type": "git", "url": "https://github.com/OpenAgInitiative/openag_firmware_module.git"}
-      ]
+      ],
+      "status_codes": {
+        "1": "No data",
+        "2": "Request failed",
+        "3": "Unknown error"
+      }
     },
     {
       "_id": "atlas_ph",
@@ -147,7 +166,12 @@
       },
       "dependencies": [
         {"type": "git", "url": "https://github.com/OpenAgInitiative/openag_firmware_module.git"}
-      ]
+      ],
+      "status_codes": {
+        "1": "No response",
+        "2": "Request failed",
+        "3": "Unknown error"
+      }
     },
     {
       "_id": "atlas_rgb",
@@ -176,7 +200,11 @@
       },
       "dependencies": [
         {"type": "git", "url": "https://github.com/OpenAgInitiative/openag_firmware_module.git"}
-      ]
+      ],
+      "status_codes": {
+        "1": "Failed to read data",
+        "2": "Invalid response. Recalibration required"
+      }
     },
     {
       "_id": "binary_actuator",
@@ -237,7 +265,10 @@
       },
       "dependencies": [
         {"type": "git", "url": "https://github.com/OpenAgInitiative/openag_firmware_module.git"}
-      ]
+      ],
+      "status_codes": {
+        "1": "Failed to read from sensor"
+      }
     },
     {
       "_id": "ds18b20",
@@ -262,7 +293,11 @@
       "dependencies": [
         {"type": "git", "url": "https://github.com/OpenAgInitiative/openag_firmware_module.git"},
         {"type": "pio", "id": 54}
-      ]
+      ],
+      "status_codes": {
+        "1": "Unable to find address for sensor",
+        "2": "Sensor isn't responding to queries"
+      }
     },
     {
       "_id": "gc0012",
@@ -287,7 +322,10 @@
       },
       "dependencies": [
         {"type": "git", "url": "https://github.com/OpenAgInitiative/openag_firmware_module.git"}
-      ]
+      ],
+      "status_codes": {
+        "2": "Failed to read from sensor"
+      }
     },
     {
       "_id": "mhz16",
@@ -312,7 +350,13 @@
       },
       "dependencies": [
         {"type": "git", "url": "https://github.com/OpenAgInitiative/openag_firmware_module.git"}
-      ]
+      ],
+      "status_codes": {
+        "1": "Initializing",
+        "2": "Sensor powered off to prevent autocalibration",
+        "3": "Failed to initialize sensor",
+        "4": "Failed to read from sensor"
+      }
     },
     {
       "_id": "pwm_actuator",
@@ -348,7 +392,10 @@
       },
       "dependencies": [
         {"type": "git", "url": "https://github.com/OpenAgInitiative/openag_firmware_module.git"}
-      ]
+      ],
+      "status_codes": {
+        "1": "Invalid command received"
+      }
     },
     {
       "_id": "software_pwm_actuator",
@@ -593,6 +640,12 @@
       }
     },
     {
+      "_id": "openag_brain:expand_diagnostics.py",
+      "package": "openag_brain",
+      "executable": "expand_diagnostics.py",
+      "description": "Reads diagnostic information coming from the arduino, converts the status codes to status messages using configuration information from the database, and republishes the information"
+    },
+    {
       "_id": "usb_cam:usb_cam_node",
       "package": "usb_cam",
       "executable": "usb_cam_node",
@@ -716,6 +769,10 @@
     {
       "_id": "api",
       "type": "openag_brain:api.py"
+    },
+    {
+      "_id": "expand_diagnostics",
+      "type": "openag_brain:expand_diagnostics.py"
     }
   ]
 }

--- a/src/openag_brain/software_modules/expand_diagnostics.py
+++ b/src/openag_brain/software_modules/expand_diagnostics.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""
+The arduino publishes openag_brain/DiagnosticArray messages to the
+/internal_diagnostics topic in ROS through rosserial. These messages are
+compacted to minimize the amount of data sent across the USB connection for
+scalablility. In particular, these messages convey status information through
+8-bit status codes instead of status messages. The firmware_module_type records
+in the database contain dictionaries that define module-specific mappings from
+these status codes to status messages. This module reads in the
+openag_brain/DiagnosticArray messages, uses the information from the database
+to "expand" the status codes to status messages, and republishes the status
+information as diagnostic_msgs/DiagnosticArray messages to use with the ROS
+diagnostic stack to ease debugging of hardware failures and displaying of
+hardware error messages.
+"""
+
+import rospy
+from openag.cli.config import config as cli_config
+from openag.utils import synthesize_firmware_module_info
+from openag.models import FirmwareModule, FirmwareModuleType
+from openag.db_names import FIRMWARE_MODULE, FIRMWARE_MODULE_TYPE
+from openag_brain.msg import DiagnosticArray as _DiagnosticArray
+from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
+from couchdb import Server
+
+class DiagnosticsExpander:
+    def __init__(self, modules):
+        self.status_codes_by_module = {
+            mod_id: {
+                int(code) : msg 
+                for code, msg in mod_info.get("status_codes", {}).items()
+            } for mod_id, mod_info in modules.items()
+        }
+        self.sub = rospy.Subscriber(
+            "/internal_diagnostics", _DiagnosticArray, self.callback
+        )
+        self.pub = rospy.Publisher(
+            "/diagnostics", DiagnosticArray, queue_size=10
+        )
+
+    def callback(self, _msg):
+        msg = DiagnosticArray()
+        statuses = []
+        for _status in _msg.status:
+            status = DiagnosticStatus()
+            status.level = _status.level
+            status.name = _status.name
+            if _status.code == 0:
+                status.message = ""
+            else:
+                status.message = self.status_codes_by_module[_status.name].get(
+                    _status.code, "Unknown error"
+                )
+            statuses.append(status)
+        msg.status = statuses
+        self.pub.publish(msg)
+
+if __name__ == '__main__':
+    rospy.init_node("expand_diagnostics")
+    db_server = cli_config["local_server"]["url"]
+    if not db_server:
+        raise RuntimeError("No local server specified")
+    server = Server(db_server)
+    module_db = server[FIRMWARE_MODULE]
+    module_type_db = server[FIRMWARE_MODULE_TYPE]
+    modules = {
+        module_id: FirmwareModule(module_db[module_id]) for module_id in
+        module_db if not module_id.startswith('_')
+    }
+    module_types = {
+        type_id: FirmwareModuleType(module_type_db[type_id]) for type_id in
+        module_type_db if not type_id.startswith('_')
+    }
+    modules = synthesize_firmware_module_info(modules, module_types)
+    expander = DiagnosticsExpander(modules)
+    rospy.spin()


### PR DESCRIPTION
This is the rest of the fix for #76 (which started with #100). It adds a software module that listens for the diagnostic messages coming from the arduino, converts the status codes in those messages to status messages using per-module_type lookup tables from the DB, and republishes the information.

Note that this PR depends on [this PR](https://github.com/OpenAgInitiative/openag_python/pull/17) in openag_python, which makes the arduino actually publish status codes instead of status messages. It also benefits from a series of PRs for the firmware module types that make those modules actually set status codes in addition to status messages.