### PR TITLE
Publish sensor info in ROS topics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ add_message_files(
   FILES
   DiagnosticStatus.msg
   DiagnosticArray.msg
+  SensorInfo.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/fixtures/default.json
+++ b/fixtures/default.json
@@ -17,10 +17,14 @@
       "description": "Driver for the am2315 sensor",
       "outputs": {
         "air_temperature": {
-          "type": "std_msgs/Float32"
+          "type": "std_msgs/Float32",
+          "accuracy": 0.1,
+          "repeatability": 0.2
         },
         "air_humidity": {
-          "type": "std_msgs/Float32"
+          "type": "std_msgs/Float32",
+          "accuracy": 2.0,
+          "repeatability": 0.1
         }
       },
       "dependencies": [

--- a/fixtures/default.json
+++ b/fixtures/default.json
@@ -597,6 +597,12 @@
       }
     },
     {
+      "_id": "openag_brain:sensor_info_publisher.py",
+      "package": "openag_brain",
+      "executable": "sensor_info_publisher.py",
+      "description": "Publishes information about the active sensors in ROS topics"
+    },
+    {
       "_id": "usb_cam:usb_cam_node",
       "package": "usb_cam",
       "executable": "usb_cam_node",
@@ -689,6 +695,10 @@
       "_id": "topic_filter_1",
       "type": "openag_brain:topic_filter.py",
       "environment": "environment_1"
+    },
+    {
+      "_id": "sensor_info_publisher",
+      "type": "openag_brain:sensor_info_publisher.py"
     },
     {
       "_id": "topic_connector",

--- a/msg/SensorInfo.msg
+++ b/msg/SensorInfo.msg
@@ -1,0 +1,2 @@
+float64 accuracy
+float64 repeatability

--- a/src/openag_brain/software_modules/sensor_info_publisher.py
+++ b/src/openag_brain/software_modules/sensor_info_publisher.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import rospy
+from openag.cli.config import config as cli_config
+from openag.utils import synthesize_firmware_module_info
+from openag.models import FirmwareModule, FirmwareModuleType
+from openag.db_names import FIRMWARE_MODULE, FIRMWARE_MODULE_TYPE
+from couchdb import Server
+from openag_brain.msg import SensorInfo
+
+def publish_sensor_info(mod_id, variable, info):
+    # Build the topic name
+    topic = "/sensors/{}/{}/info".format(mod_id, variable)
+
+    # Build the message
+    msg = SensorInfo()
+    msg.accuracy = info.get("accuracy", 0)
+    msg.repeatability = info.get("repeatability", 0)
+
+    # Publish the message
+    pub = rospy.Publisher(topic, SensorInfo, queue_size=1, latch=True)
+    pub.publish(msg)
+
+if __name__ == '__main__':
+    rospy.init_node("sensor_info_publisher")
+
+    # Connect to the DB server
+    db_server = cli_config["local_server"]["url"]
+    if not db_server:
+        raise RuntimeError("No local server specified")
+    server = Server(db_server)
+
+    # Get info on all of the modules
+    module_db = server[FIRMWARE_MODULE]
+    module_type_db = server[FIRMWARE_MODULE_TYPE]
+    modules = {
+        module_id: FirmwareModule(module_db[module_id]) for module_id in
+        module_db if not module_id.startswith('_')
+    }
+    module_types = {
+        type_id: FirmwareModuleType(module_type_db[type_id]) for type_id in
+        module_type_db if not type_id.startswith('_')
+    }
+    modules = synthesize_firmware_module_info(modules, module_types)
+
+    for module_id, module_info in modules.items():
+        for output_name, output_info in module_info["outputs"].items():
+            if not "sensors" in output_info["categories"]:
+                continue
+            publish_sensor_info(module_id, output_name, output_info)
+    rospy.spin()

--- a/src/openag_brain/software_modules/topic_connector.py
+++ b/src/openag_brain/software_modules/topic_connector.py
@@ -23,6 +23,7 @@ from couchdb import Server
 from std_msgs.msg import Bool, Float32, Float64
 
 from openag_brain import params
+from openag_brain.msg import SensorInfo
 from openag_brain.srv import Empty
 from roslib.message import get_message_class
 
@@ -43,6 +44,13 @@ def connect_topics(
         pub.publish(dest_item)
     sub = rospy.Subscriber(src_topic, src_topic_type, callback)
     return sub, pub
+
+def connect_sensor_info_topics(src_topic, dest_topic):
+    rospy.loginfo("Connecting topic {} to topic {}".format(
+        src_topic, dest_topic
+    ))
+    pub = rospy.Publisher(dest_topic, SensorInfo, queue_size=1, latch=True)
+    sub = rospy.Subscriber(src_topic, SensorInfo, pub.publish)
 
 def connect_all_topics(module_db, module_type_db):
     modules = {
@@ -81,6 +89,13 @@ def connect_all_topics(module_db, module_type_db):
             connect_topics(
                 src_topic, dest_topic, src_topic_type, dest_topic_type
             )
+            src_info_topic = "/sensors/{}/{}/info".format(
+                module_id, output_name
+            )
+            dest_info_topic = "/environments/{}/{}/info".format(
+                module_info["environment"], output_info["variable"]
+            )
+            connect_sensor_info_topics(src_info_topic, dest_info_topic)
 
 if __name__ == '__main__':
     rospy.init_node("topic_connector")


### PR DESCRIPTION
Implementation of #94. Publishes accuracy and repeatability values for each point of sensing in topics of the form `/sensors/<sensor_id>/<output_name>/info` and copies that information to topics of the form `/environments/<enironment_id>/<variable>/info`.