### PR TITLE
Implementation of categories for modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ add_service_files(
   FILES
   StartRecipe.srv
   Empty.srv
+  SetCategories.srv
 )
 
 ## Generate actions in the 'action' folder

--- a/fixtures/default.json
+++ b/fixtures/default.json
@@ -463,6 +463,7 @@
       "package": "openag_brain",
       "executable": "image_persistence.py",
       "description": "Listens for image data for a specific environment and stores it in CouchDB",
+      "categories": ["persistence"],
       "parameters": {
         "min_update_interval": {
           "type": "int",
@@ -476,6 +477,7 @@
       "package": "openag_brain",
       "executable": "pid.py",
       "description": "A Python implementation of a Proportional-Integral-Derivative controller for ROS",
+      "categories": ["control"],
       "parameters": {
         "Kp": {
           "type": "float",
@@ -539,6 +541,7 @@
       "package": "openag_brain",
       "executable": "direct_controller.py",
       "description": "A simple control loop that just interprets the set point as a direct command to the actuator",
+      "categories": ["control"],
       "parameters": {
         "variable": {
           "type": "str",
@@ -567,6 +570,7 @@
       "package": "openag_brain",
       "executable": "on_off_controller.py",
       "description": "A simple control loop that just interprets boolean set points as a direct commands to the actuator",
+      "categories": ["control"],
       "parameters": {
         "variable": {
           "type": "str",
@@ -601,6 +605,7 @@
       "package": "openag_brain",
       "executable": "sensor_persistence.py",
       "description": "Listens for measurements of environmental conditions for a specific environment and writes them to CouchDB",
+      "categories": ["persistence"],
       "parameters": {
         "max_update_interval": {
           "type": "int",
@@ -631,6 +636,7 @@
       "package": "openag_brain",
       "executable": "video_writer.py",
       "description": "Watches the DB for aerial images of the environment and makes a timelapse from them",
+      "categories": ["persistence"],
       "parameters": {
         "timelapse_scaling_factor": {
           "type": "int",
@@ -650,6 +656,7 @@
       "package": "usb_cam",
       "executable": "usb_cam_node",
       "description": "The usb_cam_node interfaces with standard USB cameras (e.g. the Logitech Quickcam) using libusb_cam and publishes images as sensor_msgs::Image. Uses the image_transport library to allow compressed image transport.",
+      "categories": ["sensors"],
       "parameters": {
         "video_device": {
           "type": "str",

--- a/scripts/main
+++ b/scripts/main
@@ -8,6 +8,7 @@ import requests
 import subprocess
 
 from openag.couch import Server
+from openag.categories import all_categories, default_categories
 from openag.cli.config import config as cli_config
 from openag.db_names import (
     SOFTWARE_MODULE, FIRMWARE_MODULE, ENVIRONMENTAL_DATA_POINT
@@ -30,7 +31,7 @@ def spawn_modules(screen=False):
         roslaunch_command.append("--screen")
     return subprocess.Popen(roslaunch_command)
 
-def main(api_server, db_server, fixtures, screen):
+def main(api_server, db_server, fixtures, screen, categories):
     # Initialize the database
     print "Initializing the database"
     db_server = db_server or cli_config["local_server"]["url"]
@@ -54,7 +55,7 @@ def main(api_server, db_server, fixtures, screen):
 
     # Start the software modules
     print "Generating launch file"
-    commands.update_launch(server)
+    commands.update_launch(server, categories=categories)
     global modules
     print "Spawning software modules"
     modules = spawn_modules(screen)
@@ -115,6 +116,12 @@ default fixtures directory.
         default=[], action='append', dest='fixture_paths'
     )
     parser.add_argument(
+        "-c", "--categories", nargs='*', default=default_categories,
+        choices=all_categories, help=""""
+The categories of modules/inputs/outputs to be enabled in this run of the
+system
+""")
+    parser.add_argument(
         "--screen", action="store_true",
         help="""
 Passes the --screen flag to the roslaunch call, which forces all node output to
@@ -125,5 +132,5 @@ the screen. Useful for debugging.
     fixture_paths = resolve_fixtures(vals.fixtures) + vals.fixture_paths
     main(
         api_server=vals.api_server, db_server=vals.db_server,
-        fixtures=fixture_paths, screen=vals.screen
+        fixtures=fixture_paths, screen=vals.screen, categories=vals.categories
     )

--- a/scripts/main
+++ b/scripts/main
@@ -6,6 +6,7 @@ import atexit
 import argparse
 import requests
 import subprocess
+import multiprocessing as mp
 
 from openag.couch import Server
 from openag.categories import all_categories, default_categories
@@ -15,6 +16,7 @@ from openag.db_names import (
 )
 
 from openag_brain import commands
+from openag_brain.srv import SetCategories
 from openag_brain.utils import resolve_fixtures
 
 modules = None
@@ -30,6 +32,31 @@ def spawn_modules(screen=False):
     if screen:
         roslaunch_command.append("--screen")
     return subprocess.Popen(roslaunch_command)
+
+def run_categories_process(queue):
+    """
+    Start a ROS service that allows the user to changes the set of categories
+    enabled in this run of the system. Whenever the service is called, it adds
+    the new list of categories to the given queue.
+
+    It is convenient to run this service in a new process on every restart
+    because `rospy` assumes that a python process will never outlive its ROS
+    core and that it will certainly never have to register itself with a series
+    of different ROS cores over time, as we would like to do here.
+    """
+    def run_process():
+        import rospy
+        rospy.init_node("categories_service")
+        def callback(req):
+            queue.put(req.categories)
+            return SetCategories._response_class(True, "OK")
+        rospy.Service(
+            "set_categories", SetCategories, callback
+        )
+        rospy.spin()
+    p = mp.Process(target=run_process)
+    p.start()
+    return p
 
 def main(api_server, db_server, fixtures, screen, categories):
     # Initialize the database
@@ -60,6 +87,10 @@ def main(api_server, db_server, fixtures, screen, categories):
     print "Spawning software modules"
     modules = spawn_modules(screen)
 
+    # Listen for calls to change the set of categories enabled
+    categories_queue = mp.Queue(1)
+    categories_process = run_categories_process(categories_queue)
+
     # Whenever the software or firmware module configuration changes, restart
     # the software modules
     software_db = server[SOFTWARE_MODULE]
@@ -77,14 +108,21 @@ def main(api_server, db_server, fixtures, screen, categories):
         firmware_changes = firmware_db.changes(since=last_firmware_seq)
         last_software_seq = software_changes["last_seq"]
         last_firmware_seq = firmware_changes["last_seq"]
-        if len(software_changes["results"]) or len(firmware_changes["results"]):
+        if len(software_changes["results"]) or len(firmware_changes["results"]) or categories_queue.full():
+            # Handle the categories service
+            if categories_queue.full():
+                categories = categories_queue.get_nowait()
+
             print "Module configuration changed; Restarting"
             modules.terminate()
+            categories_process.terminate()
+            categories_process.join()
             print "Generating launch file"
-            commands.update_launch(server)
+            commands.update_launch(server, categories=categories)
             modules.wait()
             print "Spawning software modules"
             modules = spawn_modules(screen)
+            categories_process = run_categories_process(categories_queue)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(

--- a/scripts/update_launch
+++ b/scripts/update_launch
@@ -2,6 +2,7 @@
 import argparse
 
 from couchdb import Server
+from openag.cli.config import config as cli_config
 
 from openag_brain.commands import update_launch
 
@@ -13,5 +14,6 @@ if __name__ == '__main__':
         "-D", "--db_server", help="Address of the database server"
     )
     vals = parser.parse_args()
-    server = Server(vals.db_server)
+    db_server = vals.db_server or cli_config["local_server"]["url"]
+    server = Server(db_server)
     update_launch(server)

--- a/scripts/update_launch
+++ b/scripts/update_launch
@@ -3,14 +3,15 @@ import argparse
 
 from couchdb import Server
 
-from openag_brain import args
 from openag_brain.commands import update_launch
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="Update the roslaunch file for the software modules"
     )
-    args.add_db_server_arg(parser)
+    parser.add_argument(
+        "-D", "--db_server", help="Address of the database server"
+    )
     vals = parser.parse_args()
     server = Server(vals.db_server)
     update_launch(server)

--- a/src/openag_brain/commands/update_launch.py
+++ b/src/openag_brain/commands/update_launch.py
@@ -26,7 +26,7 @@ def create_node(parent, pkg, type, name, args=None):
         e.attrib['args'] = args
     return e
 
-def create_param(parent, name, value, type):
+def create_param(parent, name, value, type=None):
     """
     Creates an xml node for the launch file that represents a ROS parameter.
     `parent` is the parent xml node. `name` is the name of the parameter to
@@ -36,7 +36,24 @@ def create_param(parent, name, value, type):
     e = ET.SubElement(parent, 'param')
     e.attrib['name'] = name
     e.attrib['value'] = value
-    e.attrib['type'] = PARAM_TYPE_MAPPING.get(type, type)
+    if type is not None:
+        e.attrib['type'] = PARAM_TYPE_MAPPING.get(type, type)
+    return e
+
+def create_list_param(parent, name, value):
+    """
+    Creates an xml node for the launch file that represents a ROS parameter
+    whose value is a list. This function is separate from `create_param`
+    because defining as an attribute is invalid in xml, so we have to use the
+    `rosparam` tag and insert the list as YAML instead.
+
+    `parent` - The parent xml node for this paramater
+    `name` - The name of the parameter to set
+    `value` - The value of the parameter
+    """
+    e = ET.SubElement(parent, 'rosparam')
+    e.attrib['param'] = name
+    e.text = str(value)
     return e
 
 def create_group(parent, ns):
@@ -83,6 +100,8 @@ def update_launch(server, categories=default_categories):
     """
     # Form a launch file from the parameter configuration
     root = ET.Element('launch')
+    create_list_param(root, "categories", categories)
+
     groups = {None: root}
 
     module_db = server[SOFTWARE_MODULE]

--- a/src/openag_brain/commands/update_launch.py
+++ b/src/openag_brain/commands/update_launch.py
@@ -8,6 +8,8 @@ from openag.models import SoftwareModule, SoftwareModuleType
 from openag.db_names import SOFTWARE_MODULE, SOFTWARE_MODULE_TYPE
 from openag.categories import default_categories, all_categories
 
+from openag_brain.params import CATEGORIES
+
 # maping from python types to roslaunch acceptable ones
 PARAM_TYPE_MAPPING = {'float' : 'double'}
 
@@ -100,7 +102,7 @@ def update_launch(server, categories=default_categories):
     """
     # Form a launch file from the parameter configuration
     root = ET.Element('launch')
-    create_list_param(root, "categories", categories)
+    create_list_param(root, CATEGORIES, categories)
 
     groups = {None: root}
 

--- a/src/openag_brain/params.py
+++ b/src/openag_brain/params.py
@@ -17,3 +17,7 @@ SUPPORTED_RECIPE_FORMATS = "supported_recipe_formats"
 Stores a comma-separated list of all of the recipe formats supported by the
 running recipe handler module
 """
+CATEGORIES = "categories"
+"""
+Stores a list of the currently active module categories
+"""

--- a/src/openag_brain/params.py
+++ b/src/openag_brain/params.py
@@ -3,8 +3,6 @@ This module stores some ROS parameter names used for passing information
 between modules in the system.
 """
 
-DEVELOPMENT = "development"
-""" Flag that indicates whether development mode is enabled """
 CURRENT_RECIPE = "current_recipe"
 """
 Stores the ID of the currently running recipe or "" if no recipe is running

--- a/srv/SetCategories.srv
+++ b/srv/SetCategories.srv
@@ -1,0 +1,4 @@
+string[] categories
+---
+bool success
+string message


### PR DESCRIPTION
This is a ROS implementation of the the concept described in [this PR](https://github.com/OpenAgInitiative/openag_python/pull/19) for `openag_python`. It establishes the concept of module "categories" that can be enabled/disabled at runtime. Now, upon running `openag_brain`, you can specify a list of "categories" that should be enabled. The script will only spawn modules that belong to at least one of these categories. The list of categories is stored in a ROS parameter for reference. The main script also now provides a service that allows the set of categories to be changed at run time. Also, the `handle_arduino` module now passes the current list of categories through to the flashing script.