### PR TITLE
Save supported_recipe_formats param as a list instead of a csv

### DIFF
--- a/src/openag_brain/software_modules/recipe_handler.py
+++ b/src/openag_brain/software_modules/recipe_handler.py
@@ -278,8 +278,7 @@ class RecipeHandler:
         rospy.Service(services.START_RECIPE, StartRecipe, self.start_recipe_service)
         rospy.Service(services.STOP_RECIPE, Empty, self.stop_recipe_service)
         rospy.set_param(
-            params.SUPPORTED_RECIPE_FORMATS,
-            ','.join(interpret_recipe.methods.keys())
+            params.SUPPORTED_RECIPE_FORMATS, interpret_recipe.methods.keys()
         )
         return self
 


### PR DESCRIPTION
I recently learned that ROS parameters are allowed to be lists. Previously, we had been storing the list of supported recipe formats in a ROS param as a CSV. This PR makes this a normal list instead. This would be a breaking change for anything that reads from this ROS parameter. I couldn't find any other code in the repo that references this parameter, but it is possible that there exists code somewhere that does.