### PR TITLE
Fix recipe handler when ROS Service stop_recipe is called

### DIFF
--- a/src/openag_brain/software_modules/handle_arduino.py
+++ b/src/openag_brain/software_modules/handle_arduino.py
@@ -11,6 +11,7 @@ this module in the system.
 
 This module has
 """
+import os
 import sys
 import time
 import rospy
@@ -37,7 +38,9 @@ class ArduinoHandler(object):
         # and initialize a firmware project within it. We'll use this
         # directory later at self.start().
         if should_flash:
-            self.build_dir = tempfile.mkdtemp()
+            self.build_dir = os.path.expanduser("~/openag_arduino")
+            if not os.path.exists(self.build_dir):
+                os.makedirs(self.build_dir)
             rospy.loginfo("Initializing firmware project for Arduino")
             proc = subprocess.Popen(
                 ["openag", "firmware", "init"], cwd=self.build_dir,


### PR DESCRIPTION
1. Moved the `current_recipe`-related ROS Param setters to the get/set with lock to ensure that stopping a recipe asynchronously via the `stop_recipe` ROS service also clears them as well (compared to just clearing them when the recipe _organically_ ends)
---

2. Fixes a crash that occurs when calling the `stop_recipe` ROS service if a recipe is **currently** running.
It is happening because the  `for` that iterates over the recipe setpoints has to `break`, then `self.clear_recipe()` is called, but the private `self._recipe` has already been cleared by the asynchronous ROS service call, so a `RecipeIdleError("No recipe is running")` is raised.


Traceback + brain logs:

```
Traceback (most recent call last):
  File "/home/pi/catkin_ws/src/openag_brain/src/openag_brain/software_modules/recipe_handler.py", line 333, in <module>
    handler.loop()
  File "/home/pi/catkin_ws/src/openag_brain/src/openag_brain/software_modules/recipe_handler.py", line 240, in loop
    self.clear_recipe()
  File "/home/pi/catkin_ws/src/openag_brain/src/openag_brain/software_modules/recipe_handler.py", line 186, in clear_recipe
    raise RecipeIdleError("No recipe is running")
__main__.RecipeIdleError: No recipe is running

[environments/environment_1/recipe_handler_1-5] process has died [pid 129, exit code 1, cmd /home/pi/catkin_ws/src/openag_brain/src/openag_brain/software_modules/recipe_handler.py __name:=recipe_handler_1 __log:=/home/pi/.ros/log/137e525c-e6b9-11e6-9957-0242ac120003/environments-environment_1-recipe_handler_1-5.log].

172.18.0.2 - - [2017-01-30 07:55:02] "POST /api/0.0.1/service/environments/environment_1/stop_recipe HTTP/1.1" 400 201 0.075140
```

In order to replicate start and stop via `rosservice` 

```
rosservice call /environments/environment_1/start_recipe test_recipe
rosservice call /environments/environment_1/stop_recipe
```

p.s. I initially added this fix to my [other PR](https://github.com/OpenAgInitiative/openag_brain/pull/99) but I'm moving it to it's own PR as it is  unrelated to the other changes to the controller modules.
