### PR TITLE
Fix recipe change race condition

### DIFF
--- a/src/openag_brain/software_modules/recipe_handler.py
+++ b/src/openag_brain/software_modules/recipe_handler.py
@@ -200,9 +200,9 @@ class RecipeHandler:
                 rospy.loginfo('Starting recipe "{}"'.format(recipe.id))
                 state = {}
                 for timestamp, variable, value in recipe:
-                    # If recipe was canceled, or ROS stopped, break setpoint
-                    # iteration
-                    if not self.get_recipe() or rospy.is_shutdown():
+                    # If recipe was canceled or changed, or ROS stopped,
+                    # break setpoint iteration
+                    if self.get_recipe() != recipe or rospy.is_shutdown():
                         break
 
                     # Skip invalid variable types

--- a/src/openag_brain/software_modules/recipe_handler.py
+++ b/src/openag_brain/software_modules/recipe_handler.py
@@ -194,15 +194,15 @@ class RecipeHandler:
             # If we have a recipe, process it. Running a recipe is a blocking
             # operation, so the recipe will stay in this turn of the loop
             # until it is finished.
-            if running_recipe:
-                rospy.set_param(params.CURRENT_RECIPE, running_recipe.id)
-                rospy.set_param(params.CURRENT_RECIPE_START, running_recipe.start_time)
-                rospy.loginfo('Starting recipe "{}"'.format(running_recipe.id))
+            if recipe:
+                rospy.set_param(params.CURRENT_RECIPE, recipe.id)
+                rospy.set_param(params.CURRENT_RECIPE_START, recipe.start_time)
+                rospy.loginfo('Starting recipe "{}"'.format(recipe.id))
                 state = {}
-                for timestamp, variable, value in running_recipe:
+                for timestamp, variable, value in recipe:
                     # If recipe was canceled or changed, or ROS stopped,
                     # break setpoint iteration
-                    if self.get_recipe() != running_recipe or rospy.is_shutdown():
+                    if self.get_recipe() != recipe or rospy.is_shutdown():
                         break
 
                     # Skip invalid variable types
@@ -241,7 +241,7 @@ class RecipeHandler:
                 # If there is a new recipe or recipe was already cleared,
                 # we do nothing, and allow the loop to turn again and pick
                 # up new recipe.
-                if self.get_recipe() == running_recipe:
+                if self.get_recipe() == recipe:
                     try:
                         self.clear_recipe()
                     except RecipeIdleError:

--- a/src/openag_brain/software_modules/recipe_handler.py
+++ b/src/openag_brain/software_modules/recipe_handler.py
@@ -195,9 +195,9 @@ class RecipeHandler:
             # operation, so the recipe will stay in this turn of the loop
             # until it is finished.
             if running_recipe:
-                rospy.set_param(params.CURRENT_RECIPE, recipe.id)
-                rospy.set_param(params.CURRENT_RECIPE_START, recipe.start_time)
-                rospy.loginfo('Starting recipe "{}"'.format(recipe.id))
+                rospy.set_param(params.CURRENT_RECIPE, running_recipe.id)
+                rospy.set_param(params.CURRENT_RECIPE_START, running_recipe.start_time)
+                rospy.loginfo('Starting recipe "{}"'.format(running_recipe.id))
                 state = {}
                 for timestamp, variable, value in running_recipe:
                     # If recipe was canceled or changed, or ROS stopped,


### PR DESCRIPTION
It used to be that if a recipe switched over too fast, we wouldn't break (because we were relying on the interim state of `__recipe` to be `None`. This fixes that.