### PR TITLE
Fix a few small grammar errors and only have one copy of installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 OpenAg Brain
 ============
 
-This repository hold code that runs on the main computing board of an OpenAg
-food computer (usually a Raspberry Pi). It runs on top on [ROS](http://www.ros.org)
+This repository holds code that runs on the main computing board of an OpenAg
+food computer (usually a Raspberry Pi). It runs on top of [ROS](http://www.ros.org)
 and uses [CouchDB](http://couchdb.apache.org/) for data storage.
 
 Installation (Raspberry Pi)

--- a/README.md
+++ b/README.md
@@ -5,65 +5,11 @@ This repository holds code that runs on the main computing board of an OpenAg
 food computer (usually a Raspberry Pi). It runs on top of [ROS](http://www.ros.org)
 and uses [CouchDB](http://couchdb.apache.org/) for data storage.
 
-Installation (Raspberry Pi)
----------------------------
+Installation & Getting Started
+------------------------------
 
-There is a pre-built Docker image for running this codebase on ARM machines.
-Most people should use this image. To set it up, follow the instructions in
-[this repo](https://github.com/OpenAgInitiative/openag_brain_docker_rpi).
+For information on how to install and run `openag_brain`, please see the
+instructions outlined in the
+[Getting Started](https://github.com/OpenAgInitiative/openag_brain/blob/master/doc/getting_started.rst)
+documentation.
 
-If you plan to modify the code in this repository, it might make more sense to
-install the software directly on your machine instead of running everything in
-a Docker container. For Raspberry Pi, this can be done by following the
-instructions in [this
-repo](https://github.com/OpenAgInitiative/openag_brain_install_rpi.git).
-
-Installation (Other Machines)
------------------------------
-
-If neither the Docker image nor the install script work for you, for whatever
-reason, you will have to install each component of the system yourself. These
-instructions describe how to do so.
-
-First, install ROS Indigo on your machine. There are installation instructions
-[here](http://wiki.ros.org/indigo/Installation/) for doing so. For Raspberry
-Pi, there are instructions
-[here](http://wiki.ros.org/ROSberryPi/Installing%20ROS%20Indigo%20on%20Raspberry%20Pi)
-instead.
-
-Next, install an instance of CouchDB on your machine. There are installation
-instructions [here](http://docs.couchdb.org/en/1.6.1/install/index.html) for
-doing so. In newer version of Ubuntu (13.10 and up), this can be done via `sudo
-apt-get install couchdb`.
-
-Create a catkin workspace as described
-[here](http://wiki.ros.org/catkin/Tutorials/create_a_workspace/) and
-install the code from this repository in the workspace.
-
-    cd ~/catkin_ws/src
-    git clone https://github.com/OpenAgInitiative/openag_brain.git -b ros
-    cd ..
-    catkin_make
-    catkin_make install
-    rosdep install -i openag_brain
-
-To run any of the openag commands, you must first activate the catkin workspace
-as follows:
-
-    source ~/catkin_ws/devel/setup.bash
-
-Finally, you must install `platformio`. `platformio` and `rosserial` use
-different versions of `pyseial`, so installing them both on the same machine
-will break things. Instead, `platformio` should be installed in a python
-virtual environment. There is a script in `openag_brain` that will do this for
-you:
-
-    rosrun openag_brain install_pio
-
-Running
--------
-
-With everything installed (not through Docker) and with the catkin workspace
-active, the project can be run as follows:
-
-    rosrun openag_brain main

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -69,8 +69,8 @@ doing so. In newer versions of Ubuntu (13.10 and up), this can be done via::
     sudo apt-get install couchdb
 
 Create a catkin workspace as described `here
-<http://wiki.ros.org/catkin/Tutorials/create_a_workspace/>`_. Then. install the
-code from the `openag_brain` repository in this workspace as follows::
+<http://wiki.ros.org/catkin/Tutorials/create_a_workspace/>`_. Then, install the
+code from the ``openag_brain`` repository in this workspace as follows::
 
     cd ~/catkin_ws/src
     git clone http://github.com/OpenAgInitiative/openag_brain.git
@@ -84,10 +84,11 @@ as follows::
 
     source ~/catkin_ws/devel/setup.bash
 
-Finally, you must install `PlatformIO`. `PlatformIO` and `rosserial` use
-different versions of `pyserial`, so installing them both on the same machine
-will break things. Instead `platformio` should be installed in a python virtual
-environment. There is a script in `openag_brain` that will do this for you::
+Finally, you must install ``PlatformIO``. ``PlatformIO`` and ``rosserial`` use
+different versions of ``pyserial``, so installing them both on the same machine
+will break things. Instead, ``platformio`` should be installed in a python
+virtual environment. There is a script in ``openag_brain`` that will do this
+for you::
 
     rosrun openag_brain install_pio
 
@@ -101,9 +102,9 @@ project can be run as follows::
     rosrun openag_brain main -f default
 
 The :code:`-f default` flag (which is also used by the Docker image) loads a
-fixture named `default` which populates the database with a basic module
+fixture named ``default`` which populates the database with a basic module
 configuration. You should be able to view the CouchDB server by going to
-`http://localhost:5984/_utils` in your browser. This is a good way to test that
-the project is actually running. See :ref:`ModuleConfiguration` for
+``http://localhost:5984/_utils`` in your browser. This is a good way to test
+that the project is actually running. See :ref:`ModuleConfiguration` for
 instructions on how to configure the software to interface with your specific
 hardware.


### PR DESCRIPTION
When I was reading through some of the documentation, I noticed a couple of very small grammar errors that I thought would be easy to fix up. I also ran across issue #107 and thought I could grab that as well while I was in here.

I am not sure if you have the documentation building anywhere yet as mentioned in #107, so the second commit in this pull request may be premature. However, I replaced the README install instructions with a link to the `docs/getting_started.rst` page for now, which could be easily updated when the docs have a new home.

Since I am a new contributor here, I wasn't sure if you would prefer that these changes be broken up into separate pull requests. I am happy to do so if desired. 