### PR TITLE
Fix regression: reintroduce independent light ctl

### DIFF
--- a/launch/personal_food_computer_v2.launch
+++ b/launch/personal_food_computer_v2.launch
@@ -32,8 +32,14 @@
     <node pkg="openag_brain" type="image_persistence.py" name="image_persistence_1">
       <param name="min_update_interval" value="3600" type="int"/>
     </node>
-    <node pkg="openag_brain" type="direct_controller.py" name="light_controller_1">
-      <param name="variable" value="light_illuminance" type="str"/>
+    <node pkg="openag_brain" type="direct_controller.py" name="light_controller_red_1">
+      <param name="variable" value="light_intensity_red" type="str"/>
+    </node>
+    <node pkg="openag_brain" type="direct_controller.py" name="light_controller_blue_1">
+      <param name="variable" value="light_intensity_blue" type="str"/>
+    </node>
+    <node pkg="openag_brain" type="direct_controller.py" name="light_controller_white_1">
+      <param name="variable" value="light_intensity_white" type="str"/>
     </node>
     <node pkg="openag_brain" type="sensor_persistence.py" name="sensor_persistence_1">
       <param name="max_update_interval" value="600" type="int"/>

--- a/launch/personal_food_computer_v2.yaml
+++ b/launch/personal_food_computer_v2.yaml
@@ -14,7 +14,7 @@ firmware_module:
   type: pwm_actuator
   inputs:
     cmd:
-      variable: light_illuminance
+      variable: light_intensity_red
 - _id: led_blue_1
   arguments:
   - 40
@@ -23,7 +23,7 @@ firmware_module:
   type: pwm_actuator
   inputs:
     cmd:
-      variable: light_illuminance
+      variable: light_intensity_blue
 - _id: led_white_1
   arguments:
   - 41
@@ -32,7 +32,7 @@ firmware_module:
   type: pwm_actuator
   inputs:
     cmd:
-      variable: light_illuminance
+      variable: light_intensity_white
 - _id: pump_1_nutrient_a_1
   arguments:
   - 28


### PR DESCRIPTION
This was a regression in config that happened in the switchover between
.json/database config and .yaml/roslaunch config.

Tested on Raspberry Pi by pushing values to `desired` topic and watching them echo to actuator `cmd` topic.