### PR TITLE
Fix topic filter comparison

### DIFF
--- a/src/openag_brain/software_modules/topic_filter.py
+++ b/src/openag_brain/software_modules/topic_filter.py
@@ -71,7 +71,7 @@ def filter_all_variable_topics(variables):
         #
         # In future, we should change the architecture of the system to support
         # standard ros types under `/environment/<id>`.
-        if env_var == WATER_LEVEL_HIGH.name:
+        if env_var == WATER_LEVEL_HIGH:
             forward_topic(src_topic, dest_topic, Float64)
         else:
             filter_topic(src_topic, dest_topic, Float64)


### PR DESCRIPTION
Within our workaround, we were comparing an instance of a class to a string,
and of course that comparison will always fail. Somehow this slipped by testing.

This commit fixes it by comparing class instance to class instance.

Tested on RPi.