### PR TITLE
Work around float -> boolean inversion conversion with deadband

### DIFF
--- a/launch/personal_food_computer_v2.yaml
+++ b/launch/personal_food_computer_v2.yaml
@@ -93,6 +93,7 @@ firmware_module:
     cmd:
       variable: water_level_high
       multiplier: -1
+      deadband: -0.5
 - _id: heater_core_1_1
   arguments:
   - 43


### PR DESCRIPTION
The PID produces a value between 1 and -1, so a -1 multiplier will result in
the reverse. A boolean produces a value between 0 and 1, so a negative multiple
will result in -1 or 0, which are both false. So that doesn't work.

We want 1 to be False
We want 0 to be True

1.0 = True
0.0 = False

When you just set multiplier of -1 on boolean floats, you get:

1.0 * -1 = -1 = False
0.0 * -1 = 0 = False

Uh-oh!

Topic connector has the concept of a deadband. Booleans are compared against the
deadband:

    if dest_topic_type == Bool:
              val = (val > deadband)

deadband = -0.5

-1.0 > -0.5 = False
0.0 > -0.5 = True