### PR TITLE
Added DS_Store to .gitignore for mac developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# For mac developers
+.DS_Store
+
 *.swp
 *.pyc
 *.egg-info


### PR DESCRIPTION
If you're developing on a mac the folder indexing native to the OS places a .DS_Store file in every folder. These show up as new files unless this is added to the .gitignore file.