### PR TITLE
Default firmware project path to ~/catkin_ws/src/openag_brain/firmware

### DIFF
--- a/doc/firmware.rst
+++ b/doc/firmware.rst
@@ -32,7 +32,13 @@ See ``launch/personal_food_computer_v2.yaml`` for an example of a firmware confi
 Building Firmware
 -----------------
 
-Firmware can be built with the `scripts/firmware` utility.
+The `install_dev` script installs [platformio](http://docs.platformio.org/en/latest/ide/atom.html), a tool for building Arduino binaries. However, before you can use the firmware build system, you need to initialize platformio **just once** from the directory you plan run the flash script in.
+
+    rosrun openag_brain init_pio
+
+This will create config files and a build space for platformio.
+
+Now, firmware can be built with the `scripts/firmware` utility.
 
 Get info on how to use it::
 

--- a/doc/firmware.rst
+++ b/doc/firmware.rst
@@ -32,13 +32,7 @@ See ``launch/personal_food_computer_v2.yaml`` for an example of a firmware confi
 Building Firmware
 -----------------
 
-The `install_dev` script installs [platformio](http://docs.platformio.org/en/latest/ide/atom.html), a tool for building Arduino binaries. However, before you can use the firmware build system, you need to initialize platformio **just once** from the directory you plan run the flash script in.
-
-    rosrun openag_brain init_pio
-
-This will create config files and a build space for platformio.
-
-Now, firmware can be built with the `scripts/firmware` utility.
+Firmware can be built with the `scripts/firmware` utility.
 
 Get info on how to use it::
 
@@ -51,6 +45,12 @@ Build firmware for personal food computer::
 Build firmware and flash to Arduino::
 
     rosrun openag_brain firmware --target upload launch/personal_food_computer_v2.yaml
+
+Under the Hood
+~~~~~~~~~~~~~~
+
+`firmware` is actually just a thin wrapper around [platformio](http://docs.platformio.org/en/latest/ide/atom.html), a tool for building Arduino binaries. The `install_dev` script installs platformio automatically.
+
 
 Authoring Firmware Modules
 --------------------------

--- a/scripts/firmware
+++ b/scripts/firmware
@@ -155,7 +155,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-d", "--project_dir",
         help="the path to the platformio project dir "
-            "(Default {}".format(),
+            "(Default {}".format(DEFAULT_PROJECT_DIR),
         default=DEFAULT_PROJECT_DIR
     )
 

--- a/scripts/firmware
+++ b/scripts/firmware
@@ -47,14 +47,12 @@ def gen_firmware(
     Generate code for this project and run it.
     Internal function we use for both run and flash commands.
     """
-    project_dir = path.abspath(project_dir)
-
     # Make sure the project has been initialized
     pio_config = path.join(project_dir, "platformio.ini")
     if not path.isfile(pio_config):
         raise RuntimeError(
             "Not an OpenAg firmware project. To initialize a new project "
-            "please use the ``openag firmware init`` command"
+            "please use \"rosrun openag_brain init_pio\" command"
         )
 
     firmware_type_params = params.get(FIRMWARE_MODULE_TYPE, [])
@@ -94,7 +92,7 @@ def gen_firmware(
     )
     pio_ids = (dep["id"] for dep in codegen.all_pio_dependencies())
     for _id in pio_ids:
-        subprocess.call(["platformio", "lib", "install", str(_id)])
+        subprocess.call(["platformio", "lib", "install", str(_id)], cwd=project_dir)
     # Create src dir if it doesn't already exist.
     try:
         makedirs(src_dir)
@@ -161,14 +159,16 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     params = yaml.load(args.param_file)
+    # Expand project dir path
+    project_dir = path.normpath(path.expanduser(args.project_dir))
     gen_firmware(
         params=params,
-        project_dir=args.project_dir,
+        project_dir=project_dir,
         categories=args.categories,
         plugin=args.plugin,
         status_update_interval=args.status_update_interval
     )
     build_firmware(
-        project_dir=args.project_dir,
+        project_dir=project_dir,
         target=args.target
     )

--- a/scripts/firmware
+++ b/scripts/firmware
@@ -32,8 +32,7 @@ from openag_lib.firmware.util import (
     load_firmware_type_manifests, load_plugin)
 
 # Relative path (from script execution) to the ROS package root.
-OPENAG_BRAIN_DIR = path.normpath(path.join(path.dirname(__file__), ".."))
-PROJECT_DIR = path.join(OPENAG_BRAIN_DIR, "firmware")
+DEFAULT_PROJECT_DIR = "~/catkin_ws/src/openag_brain/firmware"
 
 # The name of the module manifest file.
 MODULE_FILE = "module.json"
@@ -153,17 +152,23 @@ if __name__ == "__main__":
         choices=all_categories,
         nargs="*"
     )
+    parser.add_argument(
+        "-d", "--project_dir",
+        help="the path to the platformio project dir "
+            "(Default {}".format(),
+        default=DEFAULT_PROJECT_DIR
+    )
 
     args = parser.parse_args()
     params = yaml.load(args.param_file)
     gen_firmware(
         params=params,
-        project_dir=PROJECT_DIR,
+        project_dir=args.project_dir,
         categories=args.categories,
         plugin=args.plugin,
         status_update_interval=args.status_update_interval
     )
     build_firmware(
-        project_dir=PROJECT_DIR,
+        project_dir=args.project_dir,
         target=args.target
     )

--- a/scripts/init_pio
+++ b/scripts/init_pio
@@ -7,7 +7,7 @@ from os import path
 import argparse
 import subprocess
 
-FIRMWARE_PATH = path.normpath(path.join(path.dirname(__file__), '../firmware'))
+DEFAULT_PROJECT_DIR = "~/catkin_ws/src/openag_brain/firmware"
 
 parser = argparse.ArgumentParser(
     description="""
@@ -22,14 +22,14 @@ parser.add_argument(
     default="megaatmega2560"
 )
 parser.add_argument(
-    "-d", "--build_dir",
+    "-d", "--project_dir",
     help='The directory in which to initialize the PlatformIO project. '
-        'Defaults to "{}"'.format(FIRMWARE_PATH),
-    default=FIRMWARE_PATH
+        'Defaults to "{}"'.format(DEFAULT_PROJECT_DIR),
+    default=DEFAULT_PROJECT_DIR
 )
 
 
-def init(build_dir, board):
+def init(project_dir, board):
     """
     Initialize a PlatformIO project.
     Just a thin wrapper around `platformio init` that provides some defaults
@@ -39,7 +39,7 @@ def init(build_dir, board):
         init = subprocess.Popen(
             ["platformio", "init", "-b", board],
             stdin=subprocess.PIPE,
-            cwd=build_dir
+            cwd=project_dir
         )
         init.communicate("y\n")
     except OSError as e:
@@ -53,7 +53,7 @@ def init(build_dir, board):
 def main():
     args = parser.parse_args()
     init(
-        build_dir=args.build_dir,
+        project_dir=args.project_dir,
         board=args.board
     )
 

--- a/scripts/init_pio
+++ b/scripts/init_pio
@@ -52,8 +52,9 @@ def init(project_dir, board):
 
 def main():
     args = parser.parse_args()
+    project_dir = path.normpath(path.expanduser(args.project_dir))
     init(
-        project_dir=args.project_dir,
+        project_dir=project_dir,
         board=args.board
     )
 


### PR DESCRIPTION
This resolves a confusing issue where sourcing the default catkin workspace would point the script to the wrong directory for firmware by default.