### PR TITLE
Include recipe_start and recipe_end in VALID_VARIABLES

### DIFF
--- a/nodes/image_persistence.py
+++ b/nodes/image_persistence.py
@@ -96,7 +96,7 @@ if __name__ == '__main__':
         min_update_interval = 3600
     env_var_db = server[ENVIRONMENTAL_DATA_POINT]
     persistence_objs = []
-    for variable in CAMERA_VARIABLES:
+    for variable in CAMERA_VARIABLES.itervalues():
         topic = "{}/image_raw".format(variable)
         persistence_objs.append(ImagePersistence(
             db=env_var_db, topic=topic, variable=variable,

--- a/nodes/recipe_handler.py
+++ b/nodes/recipe_handler.py
@@ -38,7 +38,7 @@ RECIPE_VARIABLES = frozenset(
     VariableInfo.from_dict(d)
     for d in rospy.get_param("/var_types/recipe_variables").itervalues())
 
-VALID_VARIABLES = ENVIRONMENTAL_VARIABLES + RECIPE_VARIABLES
+VALID_VARIABLES = ENVIRONMENTAL_VARIABLES.union(RECIPE_VARIABLES)
 
 RECIPE_START = VariableInfo.from_dict(
     rospy.get_param('/var_types/recipe_variables/recipe_start'))

--- a/nodes/recipe_handler.py
+++ b/nodes/recipe_handler.py
@@ -26,18 +26,25 @@ from openag_brain.utils import gen_doc_id, read_environment_from_ns
 from openag_brain.memoize import memoize
 from openag_brain.multidispatch import multidispatch
 
-from openag_brain.load_env_var_types import create_variables
-
+from openag_brain.load_env_var_types import VariableInfo
 
 # Create a tuple constant of valid environmental variables
 # Should these be only environment_variables?
-VALID_VARIABLES = frozenset(
-                     create_variables(rospy.get_param('/var_types/environment_variables'))
-                )
+ENVIRONMENTAL_VARIABLES = frozenset(
+    VariableInfo.from_dict(d)
+    for d in rospy.get_param("/var_types/environment_variables").itervalues())
 
-# Need to check if the correct order is maintained?
-RECIPE_START, RECIPE_END = create_variables(rospy.get_param('/var_types/recipe_variables'))
+RECIPE_VARIABLES = frozenset(
+    VariableInfo.from_dict(d)
+    for d in rospy.get_param("/var_types/recipe_variables").itervalues())
 
+VALID_VARIABLES = ENVIRONMENTAL_VARIABLES + RECIPE_VARIABLES
+
+RECIPE_START = VariableInfo.from_dict(
+    rospy.get_param('/var_types/recipe_variables/recipe_start'))
+
+RECIPE_END = VariableInfo.from_dict(
+    rospy.get_param('/var_types/recipe_variables/recipe_end'))
 
 @memoize
 def publisher_memo(topic, MsgType, queue_size):

--- a/nodes/sensor_persistence.py
+++ b/nodes/sensor_persistence.py
@@ -78,7 +78,7 @@ def create_persistence_objects(
     server, environment_id, max_update_interval, min_update_interval
 ):
     env_var_db = server[ENVIRONMENTAL_DATA_POINT]
-    for variable in ENVIRONMENT_VARIABLES:
+    for variable in ENVIRONMENT_VARIABLES.itervalues():
         variable = str(variable)
         topic = "{}/measured".format(variable)
         TopicPersistence(

--- a/nodes/topic_filter.py
+++ b/nodes/topic_filter.py
@@ -92,5 +92,5 @@ def filter_all_variable_topics(variables):
 if __name__ == '__main__':
     rospy.init_node("topic_filter")
     # Make sure that we're under an environment namespace.
-    filter_all_variable_topics(ENVIRONMENT_VARIABLES)
+    filter_all_variable_topics(ENVIRONMENT_VARIABLES.values())
     rospy.spin()

--- a/nodes/video_writer.py
+++ b/nodes/video_writer.py
@@ -12,11 +12,14 @@ from openag.cli.config import config as cli_config
 from openag.couch import Server
 from openag.db_names import ENVIRONMENTAL_DATA_POINT
 from openag_brain.video_helpers import *
-from openag_brain.load_env_var_types import create_variables
+from openag_brain.load_env_var_types import create_variables, VariableInfo
 # Filter a list of environmental variables that are specific to camera
-CAMERA_VARIABLES = create_variables(rospy.get_param('/var_types/camera_variables'))
-RECIPE_START, RECIPE_END = create_variables(rospy.get_param('/var_types/recipe_variables'))
-
+CAMERA_VARIABLES = create_variables(
+    rospy.get_param('/var_types/camera_variables'))
+RECIPE_START = VariableInfo.from_dict(
+    rospy.get_param('/var_types/recipe_variables/recipe_start'))
+RECIPE_END = VariableInfo.from_dict(
+    rospy.get_param('/var_types/recipe_variables/recipe_end'))
 IMAGE_ATTACHMENT = "image"
 TIMELAPSE_ATTACHMENT = "timelapse"
 
@@ -273,7 +276,7 @@ if __name__ == '__main__':
             "designate an environment for this module."
         )
     environment = namespace.split('/')[-2]
-    for camera_var in CAMERA_VARIABLES:
+    for camera_var in CAMERA_VARIABLES.itervalues():
         mod = VideoWriter(
             server, environment, camera_var, timelapse_scaling_factor
         )

--- a/src/openag_brain/load_env_var_types.py
+++ b/src/openag_brain/load_env_var_types.py
@@ -8,16 +8,16 @@ class VariableInfo(dict):
         return VariableInfo(
             desc_dict["name"],
             desc_dict["description"],
-            ros_type=desc_dict.get("type", None),
+            type=desc_dict.get("type", None),
             units=desc_dict.get("units", None)
         )
 
-    def __init__(self, name, description, ros_type=None, units=None):
+    def __init__(self, name, description, type=None, units=None):
         self.name = name
         self.__doc__ = description
         self.units = units
         # A valid ROS type string, like std_msgs/Float64
-        self.ros_type = ros_type
+        self.type = type
     def __key(self):
         return self.name
     def __str__(self):

--- a/src/openag_brain/load_env_var_types.py
+++ b/src/openag_brain/load_env_var_types.py
@@ -1,4 +1,17 @@
 class VariableInfo(dict):
+    @staticmethod
+    def from_dict(desc_dict):
+        """
+        Construct a variable from the description dictionaries we have
+        in the yaml file.
+        """
+        return VariableInfo(
+            desc_dict["name"],
+            desc_dict["description"],
+            type=desc_dict.get("type", None),
+            units=desc_dict.get("units", None)
+        )
+
     def __init__(self, name, description, _type=None, units=None):
         self.name = name
         self.__doc__ = description

--- a/src/openag_brain/load_env_var_types.py
+++ b/src/openag_brain/load_env_var_types.py
@@ -8,15 +8,16 @@ class VariableInfo(dict):
         return VariableInfo(
             desc_dict["name"],
             desc_dict["description"],
-            type=desc_dict.get("type", None),
+            ros_type=desc_dict.get("type", None),
             units=desc_dict.get("units", None)
         )
 
-    def __init__(self, name, description, _type=None, units=None):
+    def __init__(self, name, description, ros_type=None, units=None):
         self.name = name
         self.__doc__ = description
         self.units = units
-        self.type = _type
+        # A valid ROS type string, like std_msgs/Float64
+        self.ros_type = ros_type
     def __key(self):
         return self.name
     def __str__(self):

--- a/src/openag_brain/load_env_var_types.py
+++ b/src/openag_brain/load_env_var_types.py
@@ -37,22 +37,16 @@ def create_variables(var_dict):
     """
     Converts each dictionary item into the VariableInfo class to allow for them
     to be referenced by name directly without having to look up the name key.
-    For example, print(variable) instead of print(variable['name'])
+    For example, print(variable) instead of print(variable['name']).
+    Returns a dict of VariableInfo instances.
+
     :param: var_dict : dictionary with each value being a dictionary containing
         name, description, units
     """
-    variables = []
     ## Need to change this later so it is generic to work for any number of
     ## items in the dictionary, so this file doesn't need to be modified when
     ## new items are added to the var_types definition.
-    for name, value in var_dict.items():
-        if 'units' in value:
-            if 'type' in value:
-                var = VariableInfo(name, value['description'], value['type'],
-                               value['units'])
-            else:
-                var = VariableInfo(name, value['description'], value['units'])
-        else:
-            var = VariableInfo(name, value['description'])
-        variables.append(var)
-    return variables
+    return {
+        name: VariableInfo.from_dict(desc_dict)
+        for name, desc_dict in var_dict.iteritems()
+    }

--- a/test/test_src/test_load_env_var_types.py
+++ b/test/test_src/test_load_env_var_types.py
@@ -1,4 +1,4 @@
-from src.openag_brain.load_env_var_types import create_variables
+from src.openag_brain.load_env_var_types import create_variables, VariableInfo
 
 
 var_dict = {'air_temp': {'units': 'C', 'name': 'air_temp', 'description': 'asdjalksjdf;asjkd'},
@@ -6,7 +6,9 @@ var_dict = {'air_temp': {'units': 'C', 'name': 'air_temp', 'description': 'asdja
 
 def test_create_variables():
     variables = create_variables(var_dict)
-    var_names = [str(var) for var in variables]
-    print(variables[0].name)
-    assert var_names == ['air_temp', 'air_press']
-    print(var_dict[variables[0]])
+    print(variables["air_temp"].name)
+    assert isinstance(variables["air_temp"], VariableInfo)
+    assert isinstance(variables["air_press"], VariableInfo)
+    assert variables["air_temp"].name == "air_temp"
+    assert variables["air_temp"].description == var_dict["air_temp"]["description"]
+    assert variables["air_temp"].units == var_dict["air_temp"]["units"]


### PR DESCRIPTION
Variables that aren't in the `VALID_VARIABLE` set are ignored. Since we missed including `RECIPE_START` and `RECIPE_END` in the `VALID_VARIABLE`s, it means we aren't storing a data point in the DB for those, meaning recipes will be unable to pick up across reboots of the Raspberry Pi.

Additionally, this proposes a fix for a (yet to manifest) bug caused by key ordering of dicts. Key order of dicts is not guaranteed by Python, but can be rather stable in a given implementation. We were counting on key order for `create_variables` to work properly.

Rather than reading a dict into a list, this PR lets the consumer decide how to read the dict.

A `from_dict` staticmethod is added to `VariableInfo` to give consumers an easier way to convert from YAML to class instance.