### PR TITLE
Added python-setuptools

### DIFF
--- a/scripts/init_dev
+++ b/scripts/init_dev
@@ -39,7 +39,7 @@ sudo apt-get update -q
 
 # Install pip and couchdb (couchdb is not available via rosdep -- see below)
 echo "Install pip, couchdb and ROS bootstrapping tools"
-sudo apt-get install -y -q couchdb
+sudo apt-get install -y -q couchdb python-setuptools
 # Install bootstrapping dependencies
 # We install pip with easy_install because the ARM/Debian apt package
 # `python-pip` is way out of date and causes a version conflict with Requests


### PR DESCRIPTION
Hi guys, 

I just attempted another install this morning and got the following error. It looks like the install command is missing some dependencies. [See here.](http://stackoverflow.com/questions/28265841/pip-easy-install-commands-not-working-in-ubuntu-python-2-7-and-3-4-are-install) 
Here's the error: 

`sudo: easy_install: command not found
`
Here's the full log: 

```
pi@openag:~/catkin_ws/src/openag_brain $ ./scripts/install_dev
~~~
Setting up development environment...
Location: ~/catkin_ws
~~~
Give user pi dialout permissions
Add ROS package repository
OK
Update apt
Hit http://apt.adafruit.com jessie InRelease
Get:1 http://packages.ros.org jessie InRelease [4,019 B]
Get:2 http://mirrordirector.raspbian.org jessie InRelease [12.2 kB]
Hit http://archive.raspberrypi.org jessie InRelease
Hit http://apt.adafruit.com jessie/main armhf Packages
Hit https://deb.nodesource.com jessie InRelease
Get:3 http://packages.ros.org jessie/main armhf Packages [13.3 kB]
Hit https://deb.nodesource.com jessie/main Sources
Hit http://archive.raspberrypi.org jessie/main armhf Packages
Hit https://deb.nodesource.com jessie/main armhf Packages
Get:4 https://deb.nodesource.com jessie/main Translation-en_US [162 B]
Get:5 http://mirrordirector.raspbian.org jessie/main armhf Packages [9,531 kB]
Hit http://archive.raspberrypi.org jessie/ui armhf Packages
Ign http://apt.adafruit.com jessie/main Translation-en_US
Get:6 https://deb.nodesource.com jessie/main Translation-en [162 B]
Ign http://apt.adafruit.com jessie/main Translation-en
Get:7 https://deb.nodesource.com jessie/main Translation-en_US [162 B]
Ign http://packages.ros.org jessie/main Translation-en_US
Ign http://packages.ros.org jessie/main Translation-en
Get:8 https://deb.nodesource.com jessie/main Translation-en [162 B]
Get:9 https://deb.nodesource.com jessie/main Translation-en_US [162 B]
Get:10 https://deb.nodesource.com jessie/main Translation-en [162 B]
Hit https://packagecloud.io jessie InRelease
Get:11 https://deb.nodesource.com jessie/main Translation-en_US [162 B]
Get:12 https://deb.nodesource.com jessie/main Translation-en [162 B]
Get:13 https://deb.nodesource.com jessie/main Translation-en_US [162 B]
Ign https://deb.nodesource.com jessie/main Translation-en_US
Hit https://packagecloud.io jessie/main Sources
Get:14 https://deb.nodesource.com jessie/main Translation-en [162 B]
Ign https://deb.nodesource.com jessie/main Translation-en
Hit https://packagecloud.io jessie/main armhf Packages
Get:15 https://packagecloud.io jessie/main Translation-en_US [162 B]
Get:16 https://packagecloud.io jessie/main Translation-en [162 B]
Get:17 https://packagecloud.io jessie/main Translation-en_US [162 B]
Get:18 https://packagecloud.io jessie/main Translation-en [162 B]
Get:19 https://packagecloud.io jessie/main Translation-en_US [162 B]
Get:20 https://packagecloud.io jessie/main Translation-en [162 B]
Get:21 https://packagecloud.io jessie/main Translation-en_US [162 B]
Get:22 https://packagecloud.io jessie/main Translation-en [162 B]
Get:23 https://packagecloud.io jessie/main Translation-en_US [162 B]
Ign https://packagecloud.io jessie/main Translation-en_US
Get:24 https://packagecloud.io jessie/main Translation-en [162 B]
Ign https://packagecloud.io jessie/main Translation-en
Ign http://archive.raspberrypi.org jessie/main Translation-en_US
Ign http://archive.raspberrypi.org jessie/main Translation-en
Ign http://archive.raspberrypi.org jessie/ui Translation-en_US
Ign http://archive.raspberrypi.org jessie/ui Translation-en
Get:25 http://mirrordirector.raspbian.org jessie/contrib armhf Packages [43.3 kB]
Get:26 http://mirrordirector.raspbian.org jessie/non-free armhf Packages [84.2 kB]
Get:27 http://mirrordirector.raspbian.org jessie/rpi armhf Packages [1,356 B]
Ign http://mirrordirector.raspbian.org jessie/contrib Translation-en_US
Ign http://mirrordirector.raspbian.org jessie/contrib Translation-en
Ign http://mirrordirector.raspbian.org jessie/main Translation-en_US
Ign http://mirrordirector.raspbian.org jessie/main Translation-en
Ign http://mirrordirector.raspbian.org jessie/non-free Translation-en_US
Ign http://mirrordirector.raspbian.org jessie/non-free Translation-en
Ign http://mirrordirector.raspbian.org jessie/rpi Translation-en_US
Ign http://mirrordirector.raspbian.org jessie/rpi Translation-en
Fetched 9,689 kB in 42s (226 kB/s)
Reading package lists...
Install pip, couchdb and ROS bootstrapping tools
Reading package lists...
Building dependency tree...
Reading state information...
The following extra packages will be installed:
  couchdb-bin couchdb-common erlang-asn1 erlang-base erlang-crypto erlang-eunit erlang-inets erlang-mnesia
  erlang-os-mon erlang-public-key erlang-runtime-tools erlang-snmp erlang-ssl erlang-syntax-tools erlang-tools
  erlang-webtool erlang-xmerl libmozjs185-1.0 libnspr4 libsctp1 lksctp-tools
Suggested packages:
  erlang erlang-manpages erlang-doc erlang-observer
The following NEW packages will be installed:
  couchdb couchdb-bin couchdb-common erlang-asn1 erlang-base erlang-crypto erlang-eunit erlang-inets erlang-mnesia
  erlang-os-mon erlang-public-key erlang-runtime-tools erlang-snmp erlang-ssl erlang-syntax-tools erlang-tools
  erlang-webtool erlang-xmerl libmozjs185-1.0 libnspr4 libsctp1 lksctp-tools
0 upgraded, 22 newly installed, 0 to remove and 0 not upgraded.
Need to get 19.2 MB of archives.
After this operation, 40.4 MB of additional disk space will be used.
Get:1 http://packages.ros.org/ros/ubuntu/ jessie/main couchdb-common all 1.6.0-0linarojessie1 [3,591 kB]
Get:2 http://mirrordirector.raspbian.org/raspbian/ jessie/main libnspr4 armhf 2:4.12-1+debu8u1 [95.5 kB]
Get:3 http://mirrordirector.raspbian.org/raspbian/ jessie/main libsctp1 armhf 1.0.16+dfsg-2 [27.1 kB]
Get:4 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-base armhf 1:17.3-dfsg-4+deb8u1 [6,582 kB]
Get:5 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-crypto armhf 1:17.3-dfsg-4+deb8u1 [131 kB]
Get:6 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-eunit armhf 1:17.3-dfsg-4+deb8u1 [166 kB]
Get:7 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-mnesia armhf 1:17.3-dfsg-4+deb8u1 [689 kB]
Get:8 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-runtime-tools armhf 1:17.3-dfsg-4+deb8u1 [194 kB]
Get:9 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-asn1 armhf 1:17.3-dfsg-4+deb8u1 [785 kB]
Get:10 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-public-key armhf 1:17.3-dfsg-4+deb8u1 [541 kB]
Get:11 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-ssl armhf 1:17.3-dfsg-4+deb8u1 [610 kB]
Get:12 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-inets armhf 1:17.3-dfsg-4+deb8u1 [771 kB]
Get:13 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-snmp armhf 1:17.3-dfsg-4+deb8u1 [1,559 kB]
Get:14 http://packages.ros.org/ros/ubuntu/ jessie/main couchdb-bin armhf 1.6.0-0linarojessie1 [461 kB]
Get:15 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-os-mon armhf 1:17.3-dfsg-4+deb8u1 [123 kB]
Get:16 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-syntax-tools armhf 1:17.3-dfsg-4+deb8u1 [324 kB]
Get:17 http://packages.ros.org/ros/ubuntu/ jessie/main couchdb all 1.6.0-0linarojessie1 [20.6 kB]
Get:18 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-webtool armhf 1:17.3-dfsg-4+deb8u1 [68.4 kB]
Get:19 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-tools armhf 1:17.3-dfsg-4+deb8u1 [529 kB]
Get:20 http://mirrordirector.raspbian.org/raspbian/ jessie/main erlang-xmerl armhf 1:17.3-dfsg-4+deb8u1 [997 kB]
Get:21 http://mirrordirector.raspbian.org/raspbian/ jessie/main libmozjs185-1.0 armhf 1.8.5-1.0.0+dfsg-4.3 [885 kB]
Get:22 http://mirrordirector.raspbian.org/raspbian/ jessie/main lksctp-tools armhf 1.0.16+dfsg-2 [58.8 kB]
Fetched 19.2 MB in 38s (496 kB/s)
Selecting previously unselected package libnspr4:armhf.
(Reading database ... 41067 files and directories currently installed.)
Preparing to unpack .../libnspr4_2%3a4.12-1+debu8u1_armhf.deb ...
Unpacking libnspr4:armhf (2:4.12-1+debu8u1) ...
Selecting previously unselected package libsctp1:armhf.
Preparing to unpack .../libsctp1_1.0.16+dfsg-2_armhf.deb ...
Unpacking libsctp1:armhf (1.0.16+dfsg-2) ...
Selecting previously unselected package couchdb-common.
Preparing to unpack .../couchdb-common_1.6.0-0linarojessie1_all.deb ...
Unpacking couchdb-common (1.6.0-0linarojessie1) ...
Selecting previously unselected package erlang-base.
Preparing to unpack .../erlang-base_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-base (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package erlang-crypto.
Preparing to unpack .../erlang-crypto_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-crypto (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package erlang-eunit.
Preparing to unpack .../erlang-eunit_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-eunit (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package erlang-mnesia.
Preparing to unpack .../erlang-mnesia_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-mnesia (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package erlang-runtime-tools.
Preparing to unpack .../erlang-runtime-tools_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-runtime-tools (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package erlang-asn1.
Preparing to unpack .../erlang-asn1_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-asn1 (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package erlang-public-key.
Preparing to unpack .../erlang-public-key_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-public-key (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package erlang-ssl.
Preparing to unpack .../erlang-ssl_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-ssl (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package erlang-inets.
Preparing to unpack .../erlang-inets_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-inets (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package erlang-snmp.
Preparing to unpack .../erlang-snmp_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-snmp (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package erlang-os-mon.
Preparing to unpack .../erlang-os-mon_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-os-mon (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package erlang-syntax-tools.
Preparing to unpack .../erlang-syntax-tools_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-syntax-tools (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package erlang-webtool.
Preparing to unpack .../erlang-webtool_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-webtool (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package erlang-tools.
Preparing to unpack .../erlang-tools_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-tools (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package erlang-xmerl.
Preparing to unpack .../erlang-xmerl_1%3a17.3-dfsg-4+deb8u1_armhf.deb ...
Unpacking erlang-xmerl (1:17.3-dfsg-4+deb8u1) ...
Selecting previously unselected package libmozjs185-1.0.
Preparing to unpack .../libmozjs185-1.0_1.8.5-1.0.0+dfsg-4.3_armhf.deb ...
Unpacking libmozjs185-1.0 (1.8.5-1.0.0+dfsg-4.3) ...
Selecting previously unselected package couchdb-bin.
Preparing to unpack .../couchdb-bin_1.6.0-0linarojessie1_armhf.deb ...
Unpacking couchdb-bin (1.6.0-0linarojessie1) ...
Selecting previously unselected package couchdb.
Preparing to unpack .../couchdb_1.6.0-0linarojessie1_all.deb ...
Unpacking couchdb (1.6.0-0linarojessie1) ...
Selecting previously unselected package lksctp-tools.
Preparing to unpack .../lksctp-tools_1.0.16+dfsg-2_armhf.deb ...
Unpacking lksctp-tools (1.0.16+dfsg-2) ...
Processing triggers for man-db (2.7.0.2-5) ...
Processing triggers for systemd (215-17+deb8u7) ...
Setting up libnspr4:armhf (2:4.12-1+debu8u1) ...
Setting up libsctp1:armhf (1.0.16+dfsg-2) ...
Setting up couchdb-common (1.6.0-0linarojessie1) ...
Setting up erlang-base (1:17.3-dfsg-4+deb8u1) ...
Searching for services which depend on erlang and should be started...none found.
Setting up erlang-crypto (1:17.3-dfsg-4+deb8u1) ...
Setting up erlang-eunit (1:17.3-dfsg-4+deb8u1) ...
Setting up erlang-mnesia (1:17.3-dfsg-4+deb8u1) ...
Setting up erlang-runtime-tools (1:17.3-dfsg-4+deb8u1) ...
Setting up erlang-asn1 (1:17.3-dfsg-4+deb8u1) ...
Setting up erlang-public-key (1:17.3-dfsg-4+deb8u1) ...
Setting up erlang-ssl (1:17.3-dfsg-4+deb8u1) ...
Setting up erlang-inets (1:17.3-dfsg-4+deb8u1) ...
Setting up erlang-snmp (1:17.3-dfsg-4+deb8u1) ...
Setting up erlang-os-mon (1:17.3-dfsg-4+deb8u1) ...
Setting up erlang-syntax-tools (1:17.3-dfsg-4+deb8u1) ...
Setting up erlang-webtool (1:17.3-dfsg-4+deb8u1) ...
Setting up erlang-tools (1:17.3-dfsg-4+deb8u1) ...
Setting up erlang-xmerl (1:17.3-dfsg-4+deb8u1) ...
Setting up libmozjs185-1.0 (1.8.5-1.0.0+dfsg-4.3) ...
Setting up couchdb-bin (1.6.0-0linarojessie1) ...
Setting up couchdb (1.6.0-0linarojessie1) ...
Setting up lksctp-tools (1.0.16+dfsg-2) ...
Processing triggers for libc-bin (2.19-18+deb8u9) ...
Processing triggers for systemd (215-17+deb8u7) ...
sudo: easy_install: command not found
pi@openag:~/catkin_ws/src/openag_brain $ 
```

I have confirmed my update does fix the error message and the install process.