### PR TITLE
More reliable arduino serial port assignment

### DIFF
--- a/launch/personal_food_computer_v2.launch
+++ b/launch/personal_food_computer_v2.launch
@@ -67,7 +67,6 @@
       <rosparam file="$(find openag_brain)/launch/usb_cam.yaml" />
     </node>
     <node pkg="openag_brain" type="arduino_handler.py" name="arduino_handler">
-      <param name="serial_port_id" value="/dev/ttyACM0" type="str"/>
       <param name="publisher_rate_hz" value="1" type="int"/>
       <param name="baud_rate" value="115200" type="int"/>
     </node>

--- a/nodes/arduino_handler.py
+++ b/nodes/arduino_handler.py
@@ -300,14 +300,23 @@ def process_message(line):
 if __name__ == '__main__':
     rospy.init_node('arduino_handler')
 
-    serial_port_id = rospy.get_param("~serial_port_id", "/dev/ttyACM0")
     publisher_rate_hz = rospy.get_param("~publisher_rate_hz", 1)
     baud_rate = rospy.get_param("~baud_rate", 115200)
 
     timeout_s = 1 / publisher_rate_hz
     # below: mutables (gasp!)
     # Initialize the serial connection
-    serial_connection = serial.Serial(serial_port_id, baud_rate, timeout=timeout_s)
+    path = "/dev/serial/by-id"
+    port = None
+    if not os.path.exists(path):
+      raise IOError("No serial device found on system in {}".format(path))
+
+    ports = [port for port in os.listdir(path) if "arduino" in port.lower()]
+    if len(ports) == 0:
+      raise IOError("No arduino device found on system in {}".format(path))
+    port = ports[0]
+
+    serial_connection = serial.Serial(os.path.join(path, port), baud_rate, timeout=timeout_s)
 
     # These 2 are permanently on.
     actuator_state["water_aeration_pump_1"] = True


### PR DESCRIPTION
This is a fix to #166 regarding the Arduino.

Serial devices get mapped under /dev/serial/by-id/ with a long and complicated device unique ID, but arduino devices include the phrase "arduino" in this ID.
We detect this and use that serial device instead of the /dev/ttyACM0 since that name can sometimes change.