### PR TITLE
Fix serial read buffer overflow and enable openag_brain to work with couchdb with authentication.

### DIFF
--- a/src/openag_lib/db_bootstrap/db_init.py
+++ b/src/openag_lib/db_bootstrap/db_init.py
@@ -33,14 +33,17 @@ def db_init(db_url, api_url):
     for section, param, value in config_items:
         url = urljoin(server.resource.url, "_config", section, param)
         try:
-            current_val = server.resource.session.request( "GET", url \
-                )[2].read().strip()
+            current_val = server.resource.session.request(
+                "GET", url, body = None, headers = None,
+                 credentials = server.resource.credentials
+            )[2].read().strip()
         except ResourceNotFound:
             current_val = None
         desired_val = '"{}"'.format(value.replace('"', '\\"'))
         if current_val != desired_val:
             status = server.resource.session.request(
-                "PUT", url, body=desired_val
+                "PUT", url, body = desired_val, headers = None,
+                 credentials = server.resource.credentials
             )[0]
             # Unless there is some delay between requests, CouchDB gets
             # sad for some reason


### PR DESCRIPTION
I am integrating an Alexa voice interface with the PFC which requires code running in an AWS Lambda instance to access the PFC's apis over the Internet. Therefore for security purposes its desirable to end the couchdb admin party. This PR enables openag_brain to work with couchdb with basic authentication enables. See https://github.com/goruck/foodcomputer for context and additional details. 