### PR TITLE
Air flush by volume

### DIFF
--- a/firmware/lib/openag_air_flush/openag_air_flush.h
+++ b/firmware/lib/openag_air_flush/openag_air_flush.h
@@ -7,7 +7,7 @@
 class AirFlush : public Module {
   public:
     // Constructor
-    AirFlush(int pin, bool is_active_low);
+    AirFlush(int pin, bool is_active_low, float cfm=11.7);
 
     // Public functions
     uint8_t begin();
@@ -20,7 +20,14 @@ class AirFlush : public Module {
     uint32_t _cmd_start_time;
     bool _is_active_low;
     bool _is_on;
-    uint32_t _previous_command_time;
+    float _maxCFM;
+    uint32_t _on_duration;
+    uint32_t _off_duration;
+    uint32_t _last_pulse;
+    uint32_t _cycle_ms = 60000; // 1 on/off cycle is 1 minute
+    uint32_t _shutoff_ms = 10000;
+
+    uint8_t bool2command(bool isOn);
 };
 
 #endif

--- a/firmware/src/src.ino
+++ b/firmware/src/src.ino
@@ -168,7 +168,7 @@ void actuatorLoop(){
   chiller_fan_1.set_cmd(str2bool(splitMessages[6]));              // BinaryActuator bool
   chiller_pump_1.set_cmd(str2bool(splitMessages[7]));             // BinaryActuator bool
   heater_core_2_1.set_cmd(str2bool(splitMessages[8]));            // BinaryActuator bool
-  air_flush_1.set_cmd(str2bool(splitMessages[9]));                // BinaryActuator bool
+  air_flush_1.set_cmd(splitMessages[9].toFloat());                // BinaryActuator bool
   water_aeration_pump_1.set_cmd(str2bool(splitMessages[10]));     // BinaryActuator bool
   water_circulation_pump_1.set_cmd(str2bool(splitMessages[11]));  // BinaryActuator bool
   chamber_fan_1.set_cmd(str2bool(splitMessages[12]));             // BinaryActuator bool

--- a/firmware/src/src.ino
+++ b/firmware/src/src.ino
@@ -168,7 +168,7 @@ void actuatorLoop(){
   chiller_fan_1.set_cmd(str2bool(splitMessages[6]));              // BinaryActuator bool
   chiller_pump_1.set_cmd(str2bool(splitMessages[7]));             // BinaryActuator bool
   heater_core_2_1.set_cmd(str2bool(splitMessages[8]));            // BinaryActuator bool
-  air_flush_1.set_cmd(splitMessages[9].toFloat());                // BinaryActuator bool
+  air_flush_1.set_cmd(splitMessages[9].toFloat());                // BinaryActuator float CFM 0 - 12ish
   water_aeration_pump_1.set_cmd(str2bool(splitMessages[10]));     // BinaryActuator bool
   water_circulation_pump_1.set_cmd(str2bool(splitMessages[11]));  // BinaryActuator bool
   chamber_fan_1.set_cmd(str2bool(splitMessages[12]));             // BinaryActuator bool

--- a/launch/personal_food_computer_v2.launch
+++ b/launch/personal_food_computer_v2.launch
@@ -51,10 +51,8 @@
     <node pkg="openag_brain" type="direct_controller.py" name="nutrient_flora_duo_b_controller_1">
       <param name="variable" value="nutrient_flora_duo_b" type="str"/>
     </node>
-    <node pkg="openag_brain" type="ebb_flow_controller.py" name="air_flush_on_controller_1">
-      <param name="variable" value="air_flush_on" type="str"/>
-      <param name="on_time" value="10" type="int"/>
-      <param name="off_time" value="600" type="int"/>
+    <node pkg="openag_brain" type="direct_controller.py" name="air_flush_controller_1">
+      <param name="variable" value="air_flush" type="str"/>
     </node>
     <node pkg="openag_brain" type="sensor_persistence.py" name="sensor_persistence_1">
       <param name="max_update_interval" value="600" type="int"/>

--- a/launch/personal_food_computer_var_types.yaml
+++ b/launch/personal_food_computer_var_types.yaml
@@ -28,9 +28,10 @@ environment_variables:
     description: "Oxygen density in the air"
     units: "percent"
     type: "std_msgs/Float64"
-  air_flush_on:
+  air_flush:
     name: air_flush_on
-    description: "Turn on air flush (off by default)"
+    description: "Air flush a specific volume"
+    units: "CFM"
     type: "std_msgs/Float64"
   water_temperature:
     name: water_temperature
@@ -68,12 +69,12 @@ environment_variables:
   nutrient_flora_duo_a:
     units: "ml/h"
     name: nutrient_flora_duo_a
-    description: "FloraDuo nutrient A"
+    description: "FloraDuo nutrient A volume"
     type: "std_msgs/Float64"
   nutrient_flora_duo_b:
     units: "ml/h"
     name: nutrient_flora_duo_b
-    description: "FloraDuo nutrient B"
+    description: "FloraDuo nutrient B volume"
     type: "std_msgs/Float64"
   light_illuminance:
     name: light_illuminance

--- a/launch/personal_food_computer_var_types.yaml
+++ b/launch/personal_food_computer_var_types.yaml
@@ -29,7 +29,7 @@ environment_variables:
     units: "percent"
     type: "std_msgs/Float64"
   air_flush:
-    name: air_flush_on
+    name: air_flush
     description: "Air flush a specific volume"
     units: "CFM"
     type: "std_msgs/Float64"

--- a/nodes/arduino_handler.py
+++ b/nodes/arduino_handler.py
@@ -61,7 +61,7 @@ actuator_listen_variables = (
     "water_potential_hydrogen",
     "nutrient_flora_duo_a",
     "nutrient_flora_duo_b",
-    "air_flush_on",
+    "air_flush",
     "light_intensity_red",
     "light_intensity_blue",
     "light_intensity_white",
@@ -183,9 +183,9 @@ def nutrient_flora_duo_b_callback(msg): # float
     actuator_state["pump_2_nutrient_b_1"] = command
 
 
-def air_flush_on_callback(msg): # float 0/1
+def air_flush_callback(msg): # float 0/1
     command = msg.data
-    actuator_state["air_flush_1"] = bool(command)
+    actuator_state["air_flush_1"] = float(command)
 
 
 def light_intensity_blue_callback(msg): # float 0~1
@@ -223,7 +223,7 @@ CALLBACKS = {
     "water_potential_hydrogen": water_potential_hydrogen_callback,
     "nutrient_flora_duo_a":     nutrient_flora_duo_a_callback,
     "nutrient_flora_duo_b":     nutrient_flora_duo_b_callback,
-    "air_flush_on":             air_flush_on_callback,
+    "air_flush":                air_flush_callback,
     "light_intensity_red":      light_intensity_red_callback,
     "light_intensity_blue":     light_intensity_blue_callback,
     "light_intensity_white":    light_intensity_white_callback,


### PR DESCRIPTION
This change changes the way recipes talk about the `air_flush` environmental variable(previously `air_flush_on`). We embed the CFM information of the air_flush fan into the firmware module, and write in the recipe the volume of air flush over time in `ft^3/min`. This change also deprecates the `air_flush_on` variable name and replaces it with `air_flush`. 