### PR TITLE
Respawn usb_cam_node after crash caused by usb port reconnection improve get_topic_data message and error handling

### DIFF
--- a/launch/personal_food_computer_v2.launch
+++ b/launch/personal_food_computer_v2.launch
@@ -59,11 +59,12 @@
       <param name="min_update_interval" value="5" type="int"/>
     </node>
 
-    <!-- only works if nginx and openag_ui are installed -->
+    <!-- only works if nginx and openag_ui are installed
     <node pkg="image_view" type="image_saver" name="aerial_saver">
       <remap from="image" to="aerial_image/image_raw" />
       <param name="filename_format" value="/var/www/html/img.jpg" type="string" />
     </node>
+    -->
 
     <node pkg="usb_cam" type="usb_cam_node" name="aerial_image" respawn="true">
       <rosparam file="$(find openag_brain)/launch/usb_cam.yaml" />

--- a/launch/personal_food_computer_v2.launch
+++ b/launch/personal_food_computer_v2.launch
@@ -59,14 +59,13 @@
       <param name="min_update_interval" value="5" type="int"/>
     </node>
 
-    <!-- only works if nginx and openag_ui are installed
+    <!-- only works if nginx and openag_ui are installed -->
     <node pkg="image_view" type="image_saver" name="aerial_saver">
       <remap from="image" to="aerial_image/image_raw" />
       <param name="filename_format" value="/var/www/html/img.jpg" type="string" />
     </node>
-    -->
 
-    <node pkg="usb_cam" type="usb_cam_node" name="aerial_image" respawn="true">
+    <node pkg="usb_cam" type="usb_cam_node" name="aerial_image" respawn="true" respawn_delay="30">
       <rosparam file="$(find openag_brain)/launch/usb_cam.yaml" />
     </node>
     <node pkg="openag_brain" type="arduino_handler.py" name="arduino_handler">

--- a/launch/personal_food_computer_v2.launch
+++ b/launch/personal_food_computer_v2.launch
@@ -59,14 +59,13 @@
       <param name="min_update_interval" value="5" type="int"/>
     </node>
 
-    <!-- only works if nginx and openag_ui are installed
+    <!-- only works if nginx and openag_ui are installed -->
     <node pkg="image_view" type="image_saver" name="aerial_saver">
       <remap from="image" to="aerial_image/image_raw" />
       <param name="filename_format" value="/var/www/html/img.jpg" type="string" />
     </node>
-    -->
 
-    <node pkg="usb_cam" type="usb_cam_node" name="aerial_image">
+    <node pkg="usb_cam" type="usb_cam_node" name="aerial_image" respawn="true">
       <rosparam file="$(find openag_brain)/launch/usb_cam.yaml" />
     </node>
     <node pkg="openag_brain" type="arduino_handler.py" name="arduino_handler">

--- a/nodes/api.py
+++ b/nodes/api.py
@@ -17,6 +17,9 @@ from roslib.message import get_message_class
 from flask import Flask, jsonify, request, Response
 from gevent.wsgi import WSGIServer
 from gevent.queue import Queue
+from rospy_message_converter import json_message_converter
+from PIL import Image
+from StringIO import StringIO
 
 API_VER = "0.0.1"
 
@@ -293,7 +296,7 @@ def get_topic_data(topic_name):
         "rgba8": "RGBA",
     }
     image_format = image_format_mapping.get(msg_encoding, None)
-    if image_format == None:
+    if image_format is None:
         return error("Unsupported image format", 404)
 
     # Create an image object and convert to png

--- a/nodes/api.py
+++ b/nodes/api.py
@@ -274,24 +274,36 @@ def get_topic_data(topic_name):
         raise e
     if not real_topic:
         return error("Topic does not exist", 404)
-    msg = rospy.wait_for_message(real_topic, msg_class)
-    data = getattr(msg, "data", None)
-    if data is None:
-        json = '{"status": ['
-        for x in msg.status:
-            if x == msg.status[-1]:
-                json += '{"name": \"%s\", "level": %d, "message": \"%s\", "hardware_id": \"%s\", "values": %s}]}' % \
-                        (x.name if x.name else "null", x.level, \
-                         x.message if x.message else "null", x.hardware_id if x.hardware_id else "null", \
-                         x.values)
-            else:
-                json += '{"name": \"%s\", "level": %d, "message": \"%s\", "hardware_id": \"%s\", "values": %s},' % \
-                        (x.name if x.name else "null", x.level, \
-                         x.message if x.message else "null", x.hardware_id if x.hardware_id else "null", \
-                         x.values)
-        return Response(json, mimetype = 'application/json')
-    else:
-	return jsonify({"result": data})
+
+    try:
+        msg = rospy.wait_for_message(real_topic, msg_class, timeout = 2)
+    except rospy.ROSException:
+        return error("Topic timeout", 404)
+        
+    msg_encoding = getattr(msg, "encoding", None)
+
+    # Text only, return as json
+    if msg_encoding is None:
+        json_str = json_message_converter.convert_ros_message_to_json(msg)
+        return Response(json_str, mimetype = 'application/json')
+
+    # Map format to PIL standard names
+    image_format_mapping = {
+        "rgb8": "RGB",
+        "rgba8": "RGBA",
+    }
+    image_format = image_format_mapping.get(msg_encoding, None)
+    if image_format == None:
+        return error("Unsupported image format", 404)
+
+    # Create an image object and convert to png
+    img = Image.fromstring(
+        image_format, (msg.width, msg.height), msg.data
+    )
+    buf = StringIO()
+    img.save(buf, "PNG")
+    buf.seek(0)
+    return Response(buf, mimetype = 'image/png')
 
 @app.route("/api/{v}/node".format(v=API_VER), methods=["GET"])
 def list_nodes():

--- a/scripts/generate_rosinstall
+++ b/scripts/generate_rosinstall
@@ -1,4 +1,4 @@
 #!/bin/bash
 # This script generates a .rosinstall file for our source dependencies.
 # The .rosinstall file should be kept under version control.
-rosinstall_generator ros_comm rosserial rosserial_arduino usb_cam cv_bridge image_transport image_view --rosdistro indigo --deps --wet-only --exclude roslisp --tar > ~/catkin_ws/src/openag_brain/openag_brain_ros_indigo_deps_wet.rosinstall
+rosinstall_generator ros_comm rosserial rosserial_arduino usb_cam cv_bridge image_transport image_view rospy_message_converter --rosdistro indigo --deps --wet-only --exclude roslisp --tar > ~/catkin_ws/src/openag_brain/openag_brain_ros_indigo_deps_wet.rosinstall


### PR DESCRIPTION
The usb_cam_node driver crashes frequently because the USB port loses connection with the camera and the driver tries to read from it before the port gets automatically reconnected by the Raspberry Pi's OS.

You'll see an error like the following:

```text
TRACE> arduino_handler serial read: >0,93.80,26.80,452,30.50,0,0,3.88,0.08<
[swscaler @ 0x11f3860] No accelerated colorspace conversion found from yuv422p to rgb24.
[ INFO] [1503837690.772792494]: Saved image /var/www/html/img.jpg
[ERROR] [1503837690.774624353]: Videre INI format can only save calibrations using the plumb bob distortion model. Use the YAML format instead.
	distortion_model = '', expected 'plumb_bob'
	D.size() = 0, expected 5
[ERROR] [1503837691.449486717]: VIDIOC_DQBUF error 19, No such device
[DEBUG] [WallTime: 1503837691.491640] 
TRACE> arduino_handler serial write 89 bytes: >0,0.0,0.0,False,False,False,False,False,False,0.5,True,True,True,0.0,0.0,0.0,False,False<
[WARN] [WallTime: 1503837691.493645] (5, 'Input/output error')
[WARN] [WallTime: 1503837691.503485] No serial device found on system in /dev/serial/by-id
[WARN] [WallTime: 1503837691.707030] No serial device found on system in /dev/serial/by-id
[WARN] [WallTime: 1503837691.908940] No serial device found on system in /dev/serial/by-id
[environments/environment_1/aerial_image-18] process has died [pid 8221, exit code 1, cmd /home/pi/catkin_ws/devel/lib/usb_cam/usb_cam_node __name:=aerial_image __log:=/home/pi/.ros/log/cb12cffa-8b1f-11e7-92a4-b827eb6991c6/environments-environment_1-aerial_image-18.log].
log file: /home/pi/.ros/log/cb12cffa-8b1f-11e7-92a4-b827eb6991c6/environments-environment_1-aerial_image-18*.log
[WARN] [WallTime: 1503837692.110899] No serial device found on system in /dev/serial/by-id
[WARN] [WallTime: 1503837692.312769] No serial device found on system in /dev/serial/by-id
[WARN] [WallTime: 1503837692.514701] No serial device found on system in /dev/serial/by-id
```
Note that the USB port automatically gets reconnected but not before the driver attempts a read which causes it to crash. 

The errors above are generated in the [usb_cam ros driver](https://github.com/ros-drivers/usb_cam) here:

```cpp
case IO_METHOD_MMAP:
      CLEAR(buf);

      buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
      buf.memory = V4L2_MEMORY_MMAP;

      if (-1 == xioctl(fd_, VIDIOC_DQBUF, &buf))
      {
        switch (errno)
        {
          case EAGAIN:
            return 0;

          case EIO:
            /* Could ignore EIO, see spec. */

            /* fall through */

          default:
            errno_exit("VIDIOC_DQBUF");
        }
      }
```

which caused the process to be killed:

```cpp
static void errno_exit(const char * s)
{
  ROS_ERROR("%s error %d, %s", s, errno, strerror(errno));
  exit(EXIT_FAILURE);
}
```

The simple solution is to specify the respawn = "true" attribute for the usb_cam_node in the launch file so that if it crashes ROS will automatically restart it.

This seems to work well as evidenced by the roslaunch log file:

```
[roslaunch][ERROR] 2017-09-02 12:55:32,524: [environments/environment_1/aerial_image-18] process has died [pid 20145, exit code 1, cmd /home/pi/catkin_ws/devel/lib/usb_cam/usb_cam_node __name:=aerial_image __log:=/home/pi/.ros/log/5b2f4e38-9011-11e7-b929-b827eb6991c6/environments-environment_1-aerial_image-18.log].
log file: /home/pi/.ros/log/5b2f4e38-9011-11e7-b929-b827eb6991c6/environments-environment_1-aerial_image-18*.log
[roslaunch][INFO] 2017-09-02 12:55:32,526: [environments/environment_1/aerial_image-18] restarting process
[roslaunch][INFO] 2017-09-02 12:55:32,527: process[environments/environment_1/aerial_image-18]: restarting os process
[roslaunch][INFO] 2017-09-02 12:55:32,528: process[environments/environment_1/aerial_image-18]: start w/ args [[u'/home/pi/catkin_ws/devel/lib/usb_cam/usb_cam_node', u'__name:=aerial_image', u'__log:=/home/pi/.ros/log/5b2f4e38-9011-11e7-b929-b827eb6991c6/environments-environment_1-aerial_image-18.log']]
[roslaunch][INFO] 2017-09-02 12:55:32,529: process[environments/environment_1/aerial_image-18]: cwd will be [/home/pi/.ros]
[roslaunch][INFO] 2017-09-02 12:55:32,547: process[environments/environment_1/aerial_image-18]: started with pid [20212]
```

It's not clear why the USB ports disconnect in the first place but since they get automatically reconnected this will mitigate the crash of the USB camera driver. We should still seek the root cause of the Raspberry Pi's USB ports in this regard. 