### PR TITLE
update docs to reference new dev install script

### DIFF
--- a/doc/docker.rst
+++ b/doc/docker.rst
@@ -79,7 +79,7 @@ If you want to publish Docker images under your own account, you can follow
 these steps, substituting your own Docker info:
 
 Note: this section assumes you have a development environment set up with the
-``install_dev`` script that can be found in ``openag_brain/scripts``.
+``developer_setup`` script that can be found in ``openag_brain/scripts``.
 
 First, build ROS with ``catkin_make``::
 

--- a/doc/firmware.rst
+++ b/doc/firmware.rst
@@ -49,7 +49,7 @@ Build firmware and flash to Arduino::
 Under the Hood
 ~~~~~~~~~~~~~~
 
-`firmware` is actually just a thin wrapper around [platformio](http://docs.platformio.org/en/latest/ide/atom.html), a tool for building Arduino binaries. The `install_dev` script installs platformio automatically.
+`firmware` is actually just a thin wrapper around [platformio](http://docs.platformio.org/en/latest/ide/atom.html), a tool for building Arduino binaries. The `developer_setup` script installs platformio automatically.
 
 
 Authoring Firmware Modules


### PR DESCRIPTION
Minor update to use new scripts/developer_setup instead of the old install_dev.  Due to changes to support docker builds.